### PR TITLE
UPSTREAM: <carry>: openshift: support for resourceid as an alternate image location

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/types.go
+++ b/pkg/apis/azureprovider/v1alpha1/types.go
@@ -368,11 +368,15 @@ type VM struct {
 	//AvailabilitySet *SubResource `json:"availabilitySet,omitempty"`
 }
 
+// Image is a mirror of azure sdk compute.ImageReference
 type Image struct {
+	// Fields below refer to os images in marketplace
 	Publisher string `json:"publisher"`
 	Offer     string `json:"offer"`
 	SKU       string `json:"sku"`
 	Version   string `json:"version"`
+	// ResourceID represents the location of OS Image in azure subscription
+	ResourceID string `json:"resourceID"`
 }
 
 // VMIdentity defines the identity of the virtual machine, if configured.

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -100,6 +100,18 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		return errors.Wrapf(err, "failed to generate random string")
 	}
 
+	imageReference := &compute.ImageReference{
+		Publisher: to.StringPtr(vmSpec.Image.Publisher),
+		Offer:     to.StringPtr(vmSpec.Image.Offer),
+		Sku:       to.StringPtr(vmSpec.Image.SKU),
+		Version:   to.StringPtr(vmSpec.Image.Version),
+	}
+	if vmSpec.Image.ResourceID != "" {
+		imageReference = &compute.ImageReference{
+			ID: to.StringPtr(fmt.Sprintf("/subscriptions/%s%s", s.Scope.SubscriptionID, vmSpec.Image.ResourceID)),
+		}
+	}
+
 	osProfile := &compute.OSProfile{
 		ComputerName:  to.StringPtr(vmSpec.Name),
 		AdminUsername: to.StringPtr(azure.DefaultUserName),
@@ -130,12 +142,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 				VMSize: compute.VirtualMachineSizeTypes(vmSpec.Size),
 			},
 			StorageProfile: &compute.StorageProfile{
-				ImageReference: &compute.ImageReference{
-					Publisher: to.StringPtr(vmSpec.Image.Publisher),
-					Offer:     to.StringPtr(vmSpec.Image.Offer),
-					Sku:       to.StringPtr(vmSpec.Image.SKU),
-					Version:   to.StringPtr(vmSpec.Image.Version),
-				},
+				ImageReference: imageReference,
 				OsDisk: &compute.OSDisk{
 					Name:         to.StringPtr(fmt.Sprintf("%s_OSDisk", vmSpec.Name)),
 					OsType:       compute.OperatingSystemTypes(vmSpec.OSDisk.OSType),


### PR DESCRIPTION
**What this PR does / why we need it**:

RHCOS images are never present in market place rather in alternative location, adds support for the same

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for Alternate OS Image location
```