### PR TITLE
UPSTREAM: 202 : openshift: delete OS Disks and Network interface before creating new VM instance, else fails due to previous existence

### DIFF
--- a/pkg/cloud/azure/actuators/machine/BUILD.bazel
+++ b/pkg/cloud/azure/actuators/machine/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/cloud/azure/services/availabilityzones:go_default_library",
         "//pkg/cloud/azure/services/certificates:go_default_library",
         "//pkg/cloud/azure/services/config:go_default_library",
+        "//pkg/cloud/azure/services/disks:go_default_library",
         "//pkg/cloud/azure/services/networkinterfaces:go_default_library",
         "//pkg/cloud/azure/services/virtualmachineextensions:go_default_library",
         "//pkg/cloud/azure/services/virtualmachines:go_default_library",

--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -91,3 +91,13 @@ func GenerateManagedIdentityName(subscriptionID, resourceGroupName, clusterName 
 		resourceGroupName,
 		clusterName)
 }
+
+// GenerateOSDiskName generates OS disk name used by VM
+func GenerateOSDiskName(machineName string) string {
+	return fmt.Sprintf("%s_OSDisk", machineName)
+}
+
+// GenerateNetworkInterfaceName generates network interface name used by VM
+func GenerateNetworkInterfaceName(machineName string) string {
+	return fmt.Sprintf("%s-nic", machineName)
+}

--- a/pkg/cloud/azure/services/disks/BUILD.bazel
+++ b/pkg/cloud/azure/services/disks/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "disks.go",
+        "service.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/services/disks",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cloud/azure:go_default_library",
+        "//pkg/cloud/azure/actuators:go_default_library",
+        "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)

--- a/pkg/cloud/azure/services/disks/disks.go
+++ b/pkg/cloud/azure/services/disks/disks.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disks
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
+)
+
+// Spec specification for disk
+type Spec struct {
+	Name string
+}
+
+// Get on disk is currently no-op. OS disks should only be deleted and will create with the VM automatically.
+func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error) {
+	return compute.Disk{}, nil
+}
+
+// CreateOrUpdate on disk is currently no-op. OS disks should only be deleted and will create with the VM automatically.
+func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
+	return nil
+}
+
+// Delete deletes the disk associated with a VM.
+func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
+	diskSpec, ok := spec.(*Spec)
+	if !ok {
+		return errors.New("Invalid disk specification")
+	}
+	klog.V(2).Infof("deleting disk %s", diskSpec.Name)
+	future, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.ResourceGroup, diskSpec.Name)
+	if err != nil && azure.ResourceNotFound(err) {
+		// already deleted
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete disk %s in resource group %s", diskSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
+	}
+
+	err = future.WaitForCompletionRef(ctx, s.Client.Client)
+	if err != nil {
+		return errors.Wrap(err, "cannot create, future response")
+	}
+
+	_, err = future.Result(s.Client)
+	if err != nil {
+		return errors.Wrap(err, "result error")
+	}
+	klog.V(2).Infof("successfully deleted disk %s", diskSpec.Name)
+	return err
+}

--- a/pkg/cloud/azure/services/disks/service.go
+++ b/pkg/cloud/azure/services/disks/service.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disks
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators"
+)
+
+var _ azure.Service = (*Service)(nil)
+
+// Service provides operations on resource groups
+type Service struct {
+	Client compute.DisksClient
+	Scope  *actuators.Scope
+}
+
+// getGroupsClient creates a new groups client from subscriptionid.
+func getDisksClient(subscriptionID string, authorizer autorest.Authorizer) compute.DisksClient {
+	disksClient := compute.NewDisksClient(subscriptionID)
+	disksClient.Authorizer = authorizer
+	disksClient.AddToUserAgent(azure.UserAgent)
+	return disksClient
+}
+
+// NewService creates a new groups service.
+func NewService(scope *actuators.Scope) *Service {
+	return &Service{
+		Client: getDisksClient(scope.SubscriptionID, scope.Authorizer),
+		Scope:  scope,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- When a VM fails, its deleted and recreated again (azure specific)
- During deletion OS Disk is not cleaned up, causing it to permanently fail
- PR cleans up all supporting resources created by cluster api (owned)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```