### PR TITLE
UPSTREAM: <carry>: openshift: Always consider all machines to have node role

### DIFF
--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -120,7 +120,8 @@ func (m *MachineScope) Namespace() string {
 
 // Role returns the machine role from the labels.
 func (m *MachineScope) Role() string {
-	return m.Machine.Labels[v1alpha1.MachineRoleLabel]
+	// NOTE(jchaloup): openshift actuators manage node role machines only.
+	return v1alpha1.Node
 }
 
 // Location returns the machine location.


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of minimizing the number of machine labels needed by actuators to make decisions, we want to remove `machine.openshift.io/cluster-api-machine-role` machine label, which is in Azure actuator used to distinguishes between node and control plane machine. Given openshift actuators do not create control plane machines, it's safe to assume all machines are node machines for now. 

It's impossible to remove dependency on `machine.openshift.io/cluster-api-machine-role` machine label without removing a bunch of tests relying on control plane machine role. Thus, instead of removing the label, just fallback to node role by default. Thus, eliminating the need to set `machine.openshift.io/cluster-api-machine-role` machine label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```