### PR TITLE
UPSTREAM: <carry>: openshift: Set machine.Spec.ProviderID

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -231,6 +231,18 @@ func (s *Reconciler) Update(ctx context.Context) error {
 
 	s.scope.Machine.Status.Addresses = networkAddresses
 
+	// Set provider ID
+	if vm.OsProfile != nil && vm.OsProfile.ComputerName != nil {
+		providerID := azure.GenerateMachineProviderID(
+			s.scope.SubscriptionID,
+			s.scope.ClusterConfig.ResourceGroup,
+			*vm.OsProfile.ComputerName)
+		s.scope.Machine.Spec.ProviderID = &providerID
+	} else {
+		klog.Warningf("Unable to set providerID, not able to get vm.OsProfile.ComputerName. Setting ProviderID to nil.")
+		s.scope.Machine.Spec.ProviderID = nil
+	}
+
 	return nil
 }
 

--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -97,6 +97,16 @@ func GenerateManagedIdentityName(subscriptionID, resourceGroupName, clusterName 
 		clusterName)
 }
 
+// GenerateMachineProviderID generates machine provider id.
+func GenerateMachineProviderID(subscriptionID, resourceGroupName, machineName string) string {
+	// From https://github.com/kubernetes/kubernetes/blob/e09f5c40b55c91f681a46ee17f9bc447eeacee57/pkg/cloudprovider/providers/azure/azure_standard.go#L68-L75
+	return fmt.Sprintf(
+		"azure:///subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
+		subscriptionID,
+		resourceGroupName,
+		machineName)
+}
+
 // GenerateOSDiskName generates OS disk name used by VM
 func GenerateOSDiskName(machineName string) string {
 	return fmt.Sprintf("%s_OSDisk", machineName)


### PR DESCRIPTION
Set ProviderID as is set in kubelet cloud providers, i.e. using the following template:
"azure:///subscriptions/SUBSCRIPTION/resourceGroups/RESOURCEGROUP/providers/Microsoft.Compute/virtualMachines/COMPUTERNAME".

It helps to match nodes and machines without relying on machine NodeRef field.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```