### PR TITLE
UPSTREAM: <carry>: openshift: Set instance subnet and load balancers explicitly

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -48,6 +48,18 @@ type AzureMachineProviderSpec struct {
 	SSHPublicKey  string `json:"sshPublicKey"`
 	SSHPrivateKey string `json:"sshPrivateKey"`
 	PublicIP      bool   `json:"publicIP"`
+
+	// Subnet to use for this instance
+	Subnet string `json:"subnet"`
+
+	// PublicLoadBalancer to use for this instance
+	PublicLoadBalancer string `json:"publicLoadBalancer"`
+
+	// InternalLoadBalancerName to use for this instance
+	InternalLoadBalancer string `json:"internalLoadBalancer"`
+
+	// NatRule to set inbound NAT rule of the load balancer
+	NatRule *int `json:"natRule"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/azure/actuators/machine/actuator_test.go
+++ b/pkg/cloud/azure/actuators/machine/actuator_test.go
@@ -144,7 +144,9 @@ func newFakeScope(t *testing.T, label string) *actuators.MachineScope {
 		Scope:         scope,
 		Machine:       m,
 		MachineClient: c.Machines("dummyNamespace"),
-		MachineConfig: &v1alpha1.AzureMachineProviderSpec{},
+		MachineConfig: &v1alpha1.AzureMachineProviderSpec{
+			Subnet: "dummySubnet",
+		},
 		MachineStatus: &v1alpha1.AzureMachineProviderStatus{},
 	}
 }

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -549,16 +549,21 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 		Name:     nicName,
 		VnetName: azure.GenerateVnetName(s.scope.Cluster.Name),
 	}
-	switch set := s.scope.Machine.ObjectMeta.Labels[v1alpha1.MachineRoleLabel]; set {
-	case v1alpha1.Node:
-		networkInterfaceSpec.SubnetName = azure.GenerateNodeSubnetName(s.scope.Cluster.Name)
-	case v1alpha1.ControlPlane:
-		networkInterfaceSpec.SubnetName = azure.GenerateControlPlaneSubnetName(s.scope.Cluster.Name)
-		networkInterfaceSpec.PublicLoadBalancerName = azure.GeneratePublicLBName(s.scope.Cluster.Name)
-		networkInterfaceSpec.InternalLoadBalancerName = azure.GenerateInternalLBName(s.scope.Cluster.Name)
-		networkInterfaceSpec.NatRule = 0
-	default:
-		return errors.Errorf("unknown value %s for label `set` on machine %s, skipping machine creation", set, s.scope.Machine.Name)
+
+	if s.scope.MachineConfig.Subnet == "" {
+		return errors.Errorf("MachineConfig subnet is missing on machine %s, skipping machine creation", s.scope.Machine.Name)
+	}
+
+	networkInterfaceSpec.SubnetName = s.scope.MachineConfig.Subnet
+
+	if s.scope.MachineConfig.PublicLoadBalancer != "" {
+		networkInterfaceSpec.PublicLoadBalancerName = s.scope.MachineConfig.PublicLoadBalancer
+		if s.scope.MachineConfig.NatRule != nil {
+			networkInterfaceSpec.NatRule = s.scope.MachineConfig.NatRule
+		}
+	}
+	if s.scope.MachineConfig.InternalLoadBalancer != "" {
+		networkInterfaceSpec.InternalLoadBalancerName = s.scope.MachineConfig.InternalLoadBalancer
 	}
 
 	if s.scope.MachineConfig.PublicIP {

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -38,7 +38,7 @@ type Spec struct {
 	StaticIPAddress          string
 	PublicLoadBalancerName   string
 	InternalLoadBalancerName string
-	NatRule                  int
+	NatRule                  *int
 	PublicIP                 string
 }
 
@@ -112,10 +112,12 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 			network.BackendAddressPool{
 				ID: (*lb.BackendAddressPools)[0].ID,
 			})
-		nicConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{
-			{
-				ID: (*lb.InboundNatRules)[nicSpec.NatRule].ID,
-			},
+		if nicSpec.NatRule != nil {
+			nicConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{
+				{
+					ID: (*lb.InboundNatRules)[*nicSpec.NatRule].ID,
+				},
+			}
 		}
 	}
 	if nicSpec.InternalLoadBalancerName != "" {


### PR DESCRIPTION
Do not rely on machine.openshift.io/cluster-api-machine-role label to determine
subnet name. Instead, use specific subnet so different worker machine groups
can have different subnet.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```