### PR TITLE
UPSTREAM: <carry>: openshift: Publish machine conditions during Create and Update operations

### DIFF
--- a/pkg/cloud/azure/actuators/machine/BUILD.bazel
+++ b/pkg/cloud/azure/actuators/machine/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "actuator.go",
         "annotations.go",
+        "conditions.go",
         "reconciler.go",
     ],
     importpath = "sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators/machine",
@@ -42,7 +43,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["actuator_test.go"],
+    srcs = [
+        "actuator_test.go",
+        "conditions_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/azureprovider/v1alpha1:go_default_library",

--- a/pkg/cloud/azure/actuators/machine/conditions.go
+++ b/pkg/cloud/azure/actuators/machine/conditions.go
@@ -1,0 +1,79 @@
+package machine
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1"
+)
+
+const (
+	machineCreationSucceedReason  = "MachineCreationSucceeded"
+	machineCreationSucceedMessage = "machine successfully created"
+	machineCreationFailedReason   = "MachineCreationFailed"
+)
+
+func shouldUpdateCondition(
+	oldCondition v1alpha1.AzureMachineProviderCondition,
+	newCondition v1alpha1.AzureMachineProviderCondition,
+) bool {
+	if oldCondition.Status != newCondition.Status ||
+		oldCondition.Reason != newCondition.Reason ||
+		oldCondition.Message != newCondition.Message {
+		return true
+	}
+	return false
+}
+
+// setMachineProviderCondition sets the condition for the machine and
+// returns the new slice of conditions.
+// If the machine does not already have a condition with the specified type,
+// a condition will be added to the slice.
+// If the machine does already have a condition with the specified type,
+// the condition will be updated if either of the following are true.
+// 1) Requested Status is different than existing status.
+// 2) requested Reason is different that existing one.
+// 3) requested Message is different that existing one.
+func setMachineProviderCondition(conditions []v1alpha1.AzureMachineProviderCondition, newCondition v1alpha1.AzureMachineProviderCondition) []v1alpha1.AzureMachineProviderCondition {
+	now := metav1.Now()
+	currentCondition := findCondition(conditions, newCondition.Type)
+	if currentCondition == nil {
+		klog.V(4).Infof("Adding new provider condition %v", newCondition)
+		conditions = append(
+			conditions,
+			v1alpha1.AzureMachineProviderCondition{
+				Type:               newCondition.Type,
+				Status:             newCondition.Status,
+				Reason:             newCondition.Reason,
+				Message:            newCondition.Message,
+				LastTransitionTime: now,
+				LastProbeTime:      now,
+			},
+		)
+	} else {
+		if shouldUpdateCondition(
+			*currentCondition,
+			newCondition,
+		) {
+			klog.V(4).Infof("Updating provider condition %v", newCondition)
+			if currentCondition.Status != newCondition.Status {
+				currentCondition.LastTransitionTime = now
+			}
+			currentCondition.Status = newCondition.Status
+			currentCondition.Reason = newCondition.Reason
+			currentCondition.Message = newCondition.Message
+			currentCondition.LastProbeTime = now
+		}
+	}
+	return conditions
+}
+
+// findCondition finds in the machine the condition that has the
+// specified condition type. If none exists, then returns nil.
+func findCondition(conditions []v1alpha1.AzureMachineProviderCondition, conditionType v1alpha1.AzureMachineProviderConditionType) *v1alpha1.AzureMachineProviderCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/cloud/azure/actuators/machine/conditions_test.go
+++ b/pkg/cloud/azure/actuators/machine/conditions_test.go
@@ -1,0 +1,75 @@
+package machine
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1"
+)
+
+func TestShouldUpdateCondition(t *testing.T) {
+	testCases := []struct {
+		oldCondition v1alpha1.AzureMachineProviderCondition
+		newCondition v1alpha1.AzureMachineProviderCondition
+		expected     bool
+	}{
+		{
+			oldCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "bar",
+				Status:  corev1.ConditionTrue,
+			},
+			newCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "bar",
+				Status:  corev1.ConditionTrue,
+			},
+			expected: false,
+		},
+		{
+			oldCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "bar",
+				Status:  corev1.ConditionTrue,
+			},
+			newCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "different reason",
+				Message: "bar",
+				Status:  corev1.ConditionTrue,
+			},
+			expected: true,
+		},
+		{
+			oldCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "different message",
+				Status:  corev1.ConditionTrue,
+			},
+			newCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "bar",
+				Status:  corev1.ConditionTrue,
+			},
+			expected: true,
+		},
+		{
+			oldCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "bar",
+				Status:  corev1.ConditionTrue,
+			},
+			newCondition: v1alpha1.AzureMachineProviderCondition{
+				Reason:  "foo",
+				Message: "bar",
+				Status:  corev1.ConditionFalse,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if got := shouldUpdateCondition(tc.oldCondition, tc.newCondition); got != tc.expected {
+			t.Errorf("Expected %t, got %t", got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
instance failed to be created:
```
$ kubectl get machine master-machine -o json | jq ".status.providerStatus.conditions"
[
  {
    "lastProbeTime": "2019-06-03T10:56:42Z",
    "lastTransitionTime": "2019-06-03T10:56:42Z",
    "message": "failed to create nic master-machine-nic for machine master-machine: unable to create VM network interface: subnet os4-common-node-subnet-111 not found: network.SubnetsClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code=\"NotFound\" Message=\"Resource /subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/os4-common/providers/Microsoft.Network/virtualNetworks/os4-common-vnet/subnets/os4-common-node-subnet-111 not found.\" Details=[]",
    "reason": "MachineCreationFailed",
    "status": "True",
    "type": "MachineCreated"
   }
],
```

instance created:
```
$ kubectl get machine master-machine -o json | jq ".status.providerStatus.conditions"
[
  {
    "lastProbeTime": "2019-06-03T11:04:51Z",
    "lastTransitionTime": "2019-06-03T10:56:42Z",
    "message": "machine successfully created",
    "reason": "MachineCreationSucceeded",
    "status": "True",
    "type": "MachineCreated"
  }
]
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```