### PR TITLE
UPSTREAM: <carry>: openshift: Allow to run Create/Delete ops async

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -663,7 +663,7 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName string) e
 			}
 			return errors.Errorf("vm %s is deleted, retry creating in next reconcile", s.scope.Machine.Name)
 		} else if *vm.ProvisioningState != "Succeeded" {
-			return errors.Errorf("vm %s is still in provisioningstate %s, reconcile", s.scope.Machine.Name, *vm.ProvisioningState)
+			return errors.Errorf("vm %s is still in provisioning state %s, reconcile", s.scope.Machine.Name, *vm.ProvisioningState)
 		}
 	}
 

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -191,11 +191,8 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		return errors.Wrapf(err, "cannot create vm")
 	}
 
-	err = future.WaitForCompletionRef(ctx, s.Client.Client)
-	if err != nil {
-		return errors.Wrapf(err, "cannot get the vm create or update future response")
-	}
-
+	// Do not wait until the operation completes. Just check the result
+	// so the call to Create actuator operation is async.
 	_, err = future.Result(s.Client)
 	if err != nil {
 		return err
@@ -221,11 +218,8 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 		return errors.Wrapf(err, "failed to delete vm %s in resource group %s", vmSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
 	}
 
-	err = future.WaitForCompletionRef(ctx, s.Client.Client)
-	if err != nil {
-		return errors.Wrap(err, "cannot delete, future response")
-	}
-
+	// Do not wait until the operation completes. Just check the result
+	// so the call to Delete actuator operation is async.
 	_, err = future.Result(s.Client)
 
 	klog.V(2).Infof("successfully deleted vm %s ", vmSpec.Name)


### PR DESCRIPTION
So the machine controller can reconcile multiple machines in (pseudo-)parallel manner.

During instance creation machine condition are updated
```
$ sudo kubectl get machine master-machine -o json | jq ".status.providerStatus.conditions"
[
  {
    "lastProbeTime": "2019-06-03T14:54:04Z",
    "lastTransitionTime": "2019-06-03T14:54:04Z",
    "message": "failed to create vm master-machine : vm master-machine is still in provisioningstate Creating, reconcile",
    "reason": "MachineCreationFailed",
    "status": "True",
    "type": "MachineCreated"
  }
]
```

Machine controller logs:
- E0603 17:07:49.092615   25083 actuator.go:106] failed to delete machine master-machine: failed to delete machine: compute.VirtualMachinesDeleteFuture: asynchronous operation has not completed
- E0603 16:56:06.318106   23883 actuator.go:79] failed to reconcile machine master-machine: failed to create vm master-machine : vm master-machine is still in provisioningstate Creating, reconcile

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```