### PR TITLE
UPSTREAM: <carry>: openshift: Allow vnet and managed identity names to be set explicitly

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -60,6 +60,12 @@ type AzureMachineProviderSpec struct {
 
 	// NatRule to set inbound NAT rule of the load balancer
 	NatRule *int `json:"natRule"`
+
+	// ManagedIdentity to set managed identity name
+	ManagedIdentity string `json:"managedIdentity"`
+
+	// Vnet to set virtual network name
+	Vnet string `json:"vnet"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -89,12 +89,12 @@ func GenerateFQDN(publicIPName, location string) string {
 }
 
 // GenerateManagedIdentityName generates managed identity name.
-func GenerateManagedIdentityName(subscriptionID, resourceGroupName, clusterName string) string {
+func GenerateManagedIdentityName(subscriptionID, resourceGroupName, managedIdentityName string) string {
 	return fmt.Sprintf(
-		"/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s-identity",
+		"/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s",
 		subscriptionID,
 		resourceGroupName,
-		clusterName)
+		managedIdentityName)
 }
 
 // GenerateMachineProviderID generates machine provider id.


### PR DESCRIPTION
Once installer sets both fields explictly, have machine azure actuator to require them
and fail when they are not set.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```