### PR TITLE
UPSTREAM: <carry>: openshift: Switch builds to use Go 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 as builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-azure


### PR DESCRIPTION
Switch builds to use Go 1.12