### PR TITLE
UPSTREAM: <carry>: openshift: allowing choosing availability zone for a machine

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -66,6 +66,11 @@ type AzureMachineProviderSpec struct {
 
 	// Vnet to set virtual network name
 	Vnet string `json:"vnet"`
+
+	// Availability Zone for the virtual machine.
+	// If nil, a zone will be randomly chosen from the list of zones for the location.
+	// If the virtual machine should be deployed to no zone, it must be explicitly set to empty string.
+	Zone *string `json:"zone,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -658,9 +658,14 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName string) e
 
 	vmInterface, err := s.virtualMachinesSvc.Get(ctx, vmSpec)
 	if err != nil && vmInterface == nil {
-		vmZone, zoneErr := s.getVirtualMachineZone(ctx)
-		if zoneErr != nil {
-			return errors.Wrap(zoneErr, "failed to get availability zone")
+		var vmZone string
+		if s.scope.MachineConfig.Zone == nil {
+			vmZone, err = s.getVirtualMachineZone(ctx)
+			if err != nil {
+				return errors.Wrap(err, "failed to get availability zone")
+			}
+		} else {
+			vmZone = *s.scope.MachineConfig.Zone
 		}
 
 		var managedIdentity string


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the provider, randomly chooses the Zones for a machine.
* The user must have the capability to choose the zone.
* Also allow the user to use the previous behaviour of NO zone for the machine.

**Special notes for your reviewer**:

The current implementation for IPI Azure does not use Availability Zones for IPI. The installer needs a way to enforce that on the machines.