### PR TITLE
Allow for separate Network resource group

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/azureclusterproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azureclusterproviderconfig_types.go
@@ -32,8 +32,9 @@ type AzureClusterProviderSpec struct {
 	// NetworkSpec encapsulates all things related to Azure network.
 	NetworkSpec NetworkSpec `json:"networkSpec,omitempty"`
 
-	ResourceGroup string `json:"resourceGroup"`
-	Location      string `json:"location"`
+	ResourceGroup        string `json:"resourceGroup"`
+	NetworkResourceGroup string `json:"networkResourceGroup"`
+	Location             string `json:"location"`
 
 	// CAKeyPair is the key pair for CA certs.
 	CAKeyPair KeyPair `json:"caKeyPair,omitempty"`

--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -78,6 +78,9 @@ type AzureMachineProviderSpec struct {
 	// If nil, a zone will be randomly chosen from the list of zones for the location.
 	// If the virtual machine should be deployed to no zone, it must be explicitly set to empty string.
 	Zone *string `json:"zone,omitempty"`
+
+	NetworkResourceGroup string `json:"networkResourceGroup"`
+	ResourceGroup        string `json:"resourceGroup"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -87,6 +87,16 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		}
 	}
 
+	scope.ClusterConfig.NetworkResourceGroup = scope.ClusterConfig.ResourceGroup
+
+	if machineConfig.ResourceGroup != "" {
+		scope.ClusterConfig.ResourceGroup = machineConfig.ResourceGroup
+	}
+
+	if machineConfig.NetworkResourceGroup != "" {
+		scope.ClusterConfig.NetworkResourceGroup = machineConfig.NetworkResourceGroup
+	}
+
 	return &MachineScope{
 		Scope:         scope,
 		Machine:       params.Machine,

--- a/pkg/cloud/azure/services/subnets/subnets.go
+++ b/pkg/cloud/azure/services/subnets/subnets.go
@@ -43,7 +43,7 @@ func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error)
 	if !ok {
 		return network.Subnet{}, errors.New("Invalid Subnet Specification")
 	}
-	subnet, err := s.Client.Get(ctx, s.Scope.ClusterConfig.ResourceGroup, subnetSpec.VnetName, subnetSpec.Name, "")
+	subnet, err := s.Client.Get(ctx, s.Scope.ClusterConfig.NetworkResourceGroup, subnetSpec.VnetName, subnetSpec.Name, "")
 	if err != nil && azure.ResourceNotFound(err) {
 		return nil, errors.Wrapf(err, "subnet %s not found", subnetSpec.Name)
 	} else if err != nil {
@@ -90,7 +90,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	klog.V(2).Infof("creating subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VnetName)
 	f, err := s.Client.CreateOrUpdate(
 		ctx,
-		s.Scope.ClusterConfig.ResourceGroup,
+		s.Scope.ClusterConfig.NetworkResourceGroup,
 		subnetSpec.VnetName,
 		subnetSpec.Name,
 		network.Subnet{
@@ -99,7 +99,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		},
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create subnet %s in resource group %s", subnetSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
+		return errors.Wrapf(err, "failed to create subnet %s in resource group %s", subnetSpec.Name, s.Scope.ClusterConfig.NetworkResourceGroup)
 	}
 
 	err = f.WaitForCompletionRef(ctx, s.Client.Client)
@@ -122,13 +122,13 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 		return errors.New("Invalid Subnet Specification")
 	}
 	klog.V(2).Infof("deleting subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VnetName)
-	f, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.ResourceGroup, subnetSpec.VnetName, subnetSpec.Name)
+	f, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.NetworkResourceGroup, subnetSpec.VnetName, subnetSpec.Name)
 	if err != nil && azure.ResourceNotFound(err) {
 		// already deleted
 		return nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete route table %s in resource group %s", subnetSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
+		return errors.Wrapf(err, "failed to delete route table %s in resource group %s", subnetSpec.Name, s.Scope.ClusterConfig.NetworkResourceGroup)
 	}
 
 	err = f.WaitForCompletionRef(ctx, s.Client.Client)

--- a/pkg/cloud/azure/services/virtualnetworks/virtualnetworks.go
+++ b/pkg/cloud/azure/services/virtualnetworks/virtualnetworks.go
@@ -38,7 +38,7 @@ func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error)
 	if !ok {
 		return network.VirtualNetwork{}, errors.New("Invalid VNET Specification")
 	}
-	vnet, err := s.Client.Get(ctx, s.Scope.ClusterConfig.ResourceGroup, vnetSpec.Name, "")
+	vnet, err := s.Client.Get(ctx, s.Scope.ClusterConfig.NetworkResourceGroup, vnetSpec.Name, "")
 	if err != nil && azure.ResourceNotFound(err) {
 		return nil, errors.Wrapf(err, "vnet %s not found", vnetSpec.Name)
 	} else if err != nil {
@@ -68,7 +68,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	}
 
 	klog.V(2).Infof("creating vnet %s ", vnetSpec.Name)
-	f, err := s.Client.CreateOrUpdate(ctx, s.Scope.ClusterConfig.ResourceGroup, vnetSpec.Name,
+	f, err := s.Client.CreateOrUpdate(ctx, s.Scope.ClusterConfig.NetworkResourceGroup, vnetSpec.Name,
 		network.VirtualNetwork{
 			Location: to.StringPtr(s.Scope.ClusterConfig.Location),
 			VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
@@ -101,13 +101,13 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 		return errors.New("Invalid VNET Specification")
 	}
 	klog.V(2).Infof("deleting vnet %s ", vnetSpec.Name)
-	future, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.ResourceGroup, vnetSpec.Name)
+	future, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.NetworkResourceGroup, vnetSpec.Name)
 	if err != nil && azure.ResourceNotFound(err) {
 		// already deleted
 		return nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete vnet %s in resource group %s", vnetSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
+		return errors.Wrapf(err, "failed to delete vnet %s in resource group %s", vnetSpec.Name, s.Scope.ClusterConfig.NetworkResourceGroup)
 	}
 
 	err = future.WaitForCompletionRef(ctx, s.Client.Client)


### PR DESCRIPTION
Allow for separate Network resource group

The goal is to allow networking components like the subnets, VNET to
be in a separate resource group but the resources for the cluster like
LBs, network interfaces, VMs, etc stay in the resource group of the
cluster.

The following services remain in the existing `ResourceGroup`:
- availabilityzones
- certificates
- config
- disks
- groups
- internalloadbalancers
- networkinterfaces
- publicips
- publicloadbalancers
- routetables
- securitygroups
- virtualmachineextensions
- virtualmachines

The following services are now in the new `NetworkResourceGroup`:
- subnets
- virtualnetworks

https://jira.coreos.com/browse/CLOUD-594
