### PR TITLE
UPSTREAM: <carry>: openshift: Change behaviour for zones and add unit tests

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -75,8 +75,7 @@ type AzureMachineProviderSpec struct {
 	Vnet string `json:"vnet"`
 
 	// Availability Zone for the virtual machine.
-	// If nil, a zone will be randomly chosen from the list of zones for the location.
-	// If the virtual machine should be deployed to no zone, it must be explicitly set to empty string.
+	// If nil, the virtual machine should be deployed to no zone
 	Zone *string `json:"zone,omitempty"`
 }
 

--- a/pkg/cloud/azure/actuators/machine/BUILD.bazel
+++ b/pkg/cloud/azure/actuators/machine/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/deployer:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
         "//vendor/github.com/openshift/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1:go_default_library",
         "//vendor/github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/machine/v1beta1:go_default_library",


### PR DESCRIPTION
This changes default behaviour to be deterministic and to give explicit control to the user over using zones or not and which one to choose instead of deploying to a random a zone by default. We want to provide as similar as possible user experience between cloud providers. Although in the future actuators might get smarter or/and integrate with provider specific sets/asg we design and assume for them being dumb simple and control is given to the user via inputs.
We don't want to cause the impression that actuator is smart and would smartly choose zones for you. Default behaviour should be explicit and deterministic, then as consumers we architect our solution on top to ensure we spread across zones evenly.

Orthogonal to https://github.com/openshift/installer/pull/1949#issuecomment-509590787