### PR TITLE
UPSTREAM: <carry>: openshift: Allow to run disk delete ops async

### DIFF
--- a/pkg/cloud/azure/services/disks/disks.go
+++ b/pkg/cloud/azure/services/disks/disks.go
@@ -56,11 +56,8 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 		return errors.Wrapf(err, "failed to delete disk %s in resource group %s", diskSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
 	}
 
-	err = future.WaitForCompletionRef(ctx, s.Client.Client)
-	if err != nil {
-		return errors.Wrap(err, "cannot create, future response")
-	}
-
+	// Do not wait until the operation completes. Just check the result
+	// so the call to Delete actuator operation is async.
 	_, err = future.Result(s.Client)
 	if err != nil {
 		return errors.Wrap(err, "result error")

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -221,6 +221,9 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 	// Do not wait until the operation completes. Just check the result
 	// so the call to Delete actuator operation is async.
 	_, err = future.Result(s.Client)
+	if err != nil {
+		return err
+	}
 
 	klog.V(2).Infof("successfully deleted vm %s ", vmSpec.Name)
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:

So the machine controller can delete multiple disks in (pseudo-)parallel manner.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```