### PR TITLE
UPSTREAM: <carry>: openshift: Use location from API over secret and unit test

### DIFF
--- a/pkg/cloud/azure/actuators/BUILD.bazel
+++ b/pkg/cloud/azure/actuators/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
     ],
 )

--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -97,6 +97,10 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		scope.ClusterConfig.NetworkResourceGroup = machineConfig.NetworkResourceGroup
 	}
 
+	if machineConfig.Location != "" {
+		scope.ClusterConfig.Location = machineConfig.Location
+	}
+
 	return &MachineScope{
 		Scope:         scope,
 		Machine:       params.Machine,


### PR DESCRIPTION
Use location from API over secret and unit test. In follow ups we might want to drop location and resource group from the secret