### PR TITLE
Makefile: add e2e machinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,3 +282,7 @@ verify-boilerplate:
 	./hack/verify-boilerplate.sh
 
 check: verify-boilerplate bootstrap vendor-validate lint
+
+.PHONY: test-e2e
+test-e2e:
+	hack/e2e.sh

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+GOPATH="$(mktemp -d)"
+export GOPATH
+
+ACTUATOR_PKG="github.com/openshift/cluster-api-actuator-pkg"
+
+go get -u -d "${ACTUATOR_PKG}/..."
+
+exec make --directory="${GOPATH}/src/${ACTUATOR_PKG}" test-e2e


### PR DESCRIPTION
Allows `make test-e2e` from CI to work.