### PR TITLE
UPSTREAM: <carry>: openshift: Add support for machine tags

### DIFF
--- a/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
@@ -48,13 +48,14 @@ type AzureMachineProviderSpec struct {
 	// CredentialsSecret is a reference to the secret with Azure credentials.
 	CredentialsSecret *corev1.SecretReference `json:"credentialsSecret,omitempty"`
 
-	Location      string `json:"location,omitempty"`
-	VMSize        string `json:"vmSize,omitempty"`
-	Image         Image  `json:"image"`
-	OSDisk        OSDisk `json:"osDisk"`
-	SSHPublicKey  string `json:"sshPublicKey,omitempty"`
-	SSHPrivateKey string `json:"sshPrivateKey,omitempty"`
-	PublicIP      bool   `json:"publicIP"`
+	Location      string            `json:"location,omitempty"`
+	VMSize        string            `json:"vmSize,omitempty"`
+	Image         Image             `json:"image"`
+	OSDisk        OSDisk            `json:"osDisk"`
+	SSHPublicKey  string            `json:"sshPublicKey,omitempty"`
+	SSHPrivateKey string            `json:"sshPrivateKey,omitempty"`
+	PublicIP      bool              `json:"publicIP"`
+	Tags          map[string]string `json:"tags,omitempty"`
 
 	// Subnet to use for this instance
 	Subnet string `json:"subnet"`

--- a/pkg/apis/azureprovider/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/azureprovider/v1beta1/zz_generated.deepcopy.go
@@ -60,6 +60,13 @@ func (in *AzureMachineProviderSpec) DeepCopyInto(out *AzureMachineProviderSpec) 
 	}
 	out.Image = in.Image
 	out.OSDisk = in.OSDisk
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NatRule != nil {
 		in, out := &in.NatRule, &out.NatRule
 		*out = new(int)

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -641,6 +641,7 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName string) e
 			OSDisk:          s.scope.MachineConfig.OSDisk,
 			Image:           s.scope.MachineConfig.Image,
 			Zone:            zone,
+			Tags:            s.scope.MachineConfig.Tags,
 			ManagedIdentity: azure.GenerateManagedIdentityName(s.scope.SubscriptionID, s.scope.ClusterConfig.ResourceGroup, s.scope.MachineConfig.ManagedIdentity),
 		}
 

--- a/pkg/cloud/azure/services/virtualmachines/BUILD.bazel
+++ b/pkg/cloud/azure/services/virtualmachines/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -21,4 +21,11 @@ go_library(
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["virtualmachines_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library"],
 )

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -45,6 +45,7 @@ type Spec struct {
 	OSDisk          v1beta1.OSDisk
 	CustomData      string
 	ManagedIdentity string
+	Tags            map[string]string
 }
 
 // Get provides information about a virtual network.
@@ -138,6 +139,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 
 	virtualMachine := compute.VirtualMachine{
 		Location: to.StringPtr(s.Scope.ClusterConfig.Location),
+		Tags:     getTagListFromSpec(vmSpec),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
 				VMSize: compute.VirtualMachineSizeTypes(vmSpec.Size),
@@ -200,6 +202,18 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 
 	klog.V(2).Infof("successfully created vm %s ", vmSpec.Name)
 	return err
+}
+
+func getTagListFromSpec(spec *Spec) map[string]*string {
+	if len(spec.Tags) < 1 {
+		return nil
+	}
+
+	tagList := map[string]*string{}
+	for key, element := range spec.Tags {
+		tagList[key] = to.StringPtr(element)
+	}
+	return tagList
 }
 
 // Delete deletes the virtual network with the provided name.

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_test.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_test.go
@@ -1,0 +1,40 @@
+package virtualmachines
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func TestGetTagListFromSpec(t *testing.T) {
+	testCases := []struct {
+		spec     *Spec
+		expected map[string]*string
+	}{
+		{
+			spec: &Spec{
+				Name: "test",
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			expected: map[string]*string{
+				"foo": to.StringPtr("bar"),
+			},
+		},
+		{
+			spec: &Spec{
+				Name: "test",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		tagList := getTagListFromSpec(tc.spec)
+		if !reflect.DeepEqual(tagList, tc.expected) {
+			t.Errorf("Expected %v, got: %v", tc.expected, tagList)
+		}
+	}
+}


### PR DESCRIPTION
All of the clouds allow you to tag their VMs with metadata tags.  So you can filter and do a ton of other activities that fall out of having tags.

We want to expose a tags field on the API on azure and honour it on the actuator implementation for machines.