### PR TITLE
UPSTREAM: <carry>: openshift: do not randomize public ip name, error instead

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -452,11 +452,18 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 		return errors.Wrapf(err, "Unable to delete network interface")
 	}
 
-	err = s.publicIPSvc.Delete(ctx, &publicips.Spec{
-		Name: azure.GenerateMachinePublicIPName(s.scope.Cluster.Name, s.scope.Machine.Name),
-	})
-	if err != nil {
-		return errors.Wrap(err, "unable to delete Public IP")
+	if s.scope.MachineConfig.PublicIP {
+		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.Cluster.Name, s.scope.Machine.Name)
+		if err != nil {
+			return errors.Wrap(err, "unable to create Public IP")
+		}
+
+		err = s.publicIPSvc.Delete(ctx, &publicips.Spec{
+			Name: publicIPName,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to delete Public IP")
+		}
 	}
 
 	return nil
@@ -596,8 +603,11 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 	}
 
 	if s.scope.MachineConfig.PublicIP {
-		publicIPName := azure.GenerateMachinePublicIPName(s.scope.Cluster.Name, s.scope.Machine.Name)
-		err := s.publicIPSvc.CreateOrUpdate(ctx, &publicips.Spec{Name: publicIPName})
+		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.Cluster.Name, s.scope.Machine.Name)
+		if err != nil {
+			return errors.Wrap(err, "unable to create Public IP")
+		}
+		err = s.publicIPSvc.CreateOrUpdate(ctx, &publicips.Spec{Name: publicIPName})
 		if err != nil {
 			return errors.Wrap(err, "unable to create Public IP")
 		}

--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package azure
 
-import (
-	"fmt"
-
-	uuid "github.com/satori/go.uuid"
-)
+import "fmt"
 
 const (
 	// DefaultUserName is the default username for created vm
@@ -83,15 +79,13 @@ func GeneratePublicIPName(clusterName, hash string) string {
 }
 
 // GenerateMachinePublicIPName generates a public IP name for a machine, based on the cluster name and a hash.
-func GenerateMachinePublicIPName(clusterName, machineName string) string {
+func GenerateMachinePublicIPName(clusterName, machineName string) (string, error) {
 	name := GeneratePublicIPName(clusterName, machineName)
 	if len(name) < 64 {
-		return name
+		return name, nil
 	}
-	hash := uuid.NewV4().String()
-	hashlen := len(hash)
 
-	return name[:63-hashlen] + hash
+	return "", fmt.Errorf("machine public IP name is longer than 63 characters")
 }
 
 // GenerateFQDN generates a fully qualified domain name, based on the public IP name and cluster location.

--- a/pkg/cloud/azure/defaults_test.go
+++ b/pkg/cloud/azure/defaults_test.go
@@ -10,6 +10,7 @@ func TestGenerateMachinePublicIPName(t *testing.T) {
 		name        string
 		clusterName string
 		machineName string
+		err         bool
 	}{
 		{
 			name:        "Public IP name length less than 64",
@@ -17,14 +18,21 @@ func TestGenerateMachinePublicIPName(t *testing.T) {
 			machineName: "machine",
 		},
 		{
-			name:        "Public IP name length with at least 64 is truncated to 63",
+			name:        "Public IP name length with at least 64 errors",
 			clusterName: "clusterName",
 			machineName: strings.Repeat("0123456789", 6),
+			err:         true,
 		},
 	}
 
 	for _, test := range tests {
-		name := GenerateMachinePublicIPName(test.clusterName, test.machineName)
+		name, err := GenerateMachinePublicIPName(test.clusterName, test.machineName)
+		if test.err && err == nil {
+			t.Errorf("Expected error, got none")
+		}
+		if !test.err && err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
 		t.Logf("%v: generated name: %v", test.name, name)
 		if len(name) > 63 {
 			t.Errorf("%v: generated public IP name is longer than 63 chars (%v)", test.name, len(name))


### PR DESCRIPTION
Generated ip public name has to be the same all the time since the name is generated in two different operations (Create and Delete) which are independent of each other. Unless the public ip name is stored in machine status, the delete has to get the same name as the create operation to delete the resource from Azure.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```