### PR TITLE
Check if annotations are initialized before assigning a key

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -422,6 +422,9 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 
 	// Getting a vm object does not work here so let's assume
 	// an instance is really being deleted
+	if s.scope.Machine.Annotations == nil {
+		s.scope.Machine.Annotations = make(map[string]string)
+	}
 	s.scope.Machine.Annotations[MachineInstanceStateAnnotationName] = string(v1beta1.VMStateDeleting)
 	s.scope.MachineStatus.VMState = &v1beta1.VMStateDeleting
 


### PR DESCRIPTION
E0817 08:16:19.223388       1 runtime.go:69] Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:76
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/panic.go:522
/usr/local/go/src/runtime/map_faststr.go:204
/go/src/sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators/machine/reconciler.go:425
/go/src/sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators/machine/actuator.go:140
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/github.com/openshift/cluster-api/pkg/controller/machine/controller.go:219
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:216
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:192
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:171
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153
/go/src/sigs.k8s.io/cluster-api-provider-azure/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:1337
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```