### PR TITLE
UPSTREAM: <carry>: openshift: Extend makefile with 'make goimports' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,10 @@ deploy: manifests
 fmt:
 	go fmt ./pkg/... ./cmd/...
 
+.PHONY: goimports
+goimports: ## Go fmt your code
+	hack/goimports.sh .
+
 # Run go vet against code
 vet:
 	go vet -composites=false ./pkg/... ./cmd/... 

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+REPO_NAME=$(basename "${PWD}")
+if [ "$IS_CONTAINER" != "" ]; then
+  for TARGET in "${@}"; do
+    find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+
+  done
+  git diff --exit-code
+else
+  docker run -it --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
+    openshift/origin-release:golang-1.12 \
+    ./hack/goimports.sh "${@}"
+fi

--- a/pkg/cloud/azure/mock/client_generated.go
+++ b/pkg/cloud/azure/mock/client_generated.go
@@ -6,8 +6,9 @@ package mock_azure
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 	azure "sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
 )
 

--- a/pkg/cloud/azure/services/internalloadbalancers/internalloadbalancers.go
+++ b/pkg/cloud/azure/services/internalloadbalancers/internalloadbalancers.go
@@ -90,8 +90,8 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 						Name: &frontEndIPConfigName,
 						FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 							PrivateIPAllocationMethod: network.Static,
-							Subnet:                    &subnet,
-							PrivateIPAddress:          to.StringPtr(internalLBSpec.IPAddress),
+							Subnet:           &subnet,
+							PrivateIPAddress: to.StringPtr(internalLBSpec.IPAddress),
 						},
 					},
 				},

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -145,7 +145,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 			InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 				IPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name:                                     to.StringPtr("pipConfig"),
+						Name: to.StringPtr("pipConfig"),
 						InterfaceIPConfigurationPropertiesFormat: nicConfig,
 					},
 				},

--- a/pkg/cloud/azure/services/subnets/subnets.go
+++ b/pkg/cloud/azure/services/subnets/subnets.go
@@ -94,7 +94,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		subnetSpec.VnetName,
 		subnetSpec.Name,
 		network.Subnet{
-			Name:                   to.StringPtr(subnetSpec.Name),
+			Name: to.StringPtr(subnetSpec.Name),
 			SubnetPropertiesFormat: &subnetProperties,
 		},
 	)


### PR DESCRIPTION
So the target can be run in CI and fail in case files are not properly goimport formated.