### PR TITLE
UPSTREAM: <carry>: openshift: Resync every 20 seconds

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -110,7 +110,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		}
 		a.handleMachineError(machine, apierrors.CreateMachine("failed to reconcile machine %qs: %v", machine.Name, err), createEventAction)
 		return &controllerError.RequeueAfterError{
-			RequeueAfter: time.Minute,
+			RequeueAfter: 20 * time.Second,
 		}
 	}
 
@@ -145,7 +145,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 		}
 		a.handleMachineError(machine, apierrors.DeleteMachine("failed to delete machine %q: %v", machine.Name, err), deleteEventAction)
 		return &controllerError.RequeueAfterError{
-			RequeueAfter: time.Minute,
+			RequeueAfter: 20 * time.Second,
 		}
 	}
 
@@ -182,7 +182,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 		}
 		a.handleMachineError(machine, apierrors.UpdateMachine("failed to update machine %q: %v", machine.Name, err), updateEventAction)
 		return &controllerError.RequeueAfterError{
-			RequeueAfter: time.Minute,
+			RequeueAfter: 20 * time.Second,
 		}
 	}
 


### PR DESCRIPTION
Multiple of a minute is too wide window to wait for a machine to be created
in case the instance creation fails. In practice, it's between 2 minutes and
3 minutes (closer to 2 minutes). Resyncing the machines 3 times faster will
also help to pop machines from the queue sooner and improve actuator's response
when creating hundreds of machines simultaniously.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```