### PR TITLE
UPSTREAM: <carry>: openshift: tag instances with cluster id

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator_test.go
+++ b/pkg/cloud/azure/actuators/machine/actuator_test.go
@@ -143,6 +143,7 @@ func newFakeScope(t *testing.T, label string) *actuators.MachineScope {
 	scope.Network().APIServerIP.DNSName = "DummyDNSName"
 	labels := make(map[string]string)
 	labels[machineproviderv1.MachineRoleLabel] = label
+	labels[machinev1.MachineClusterIDLabel] = "clusterID"
 	machineConfig := machineproviderv1.AzureMachineProviderSpec{}
 	m := newMachine(t, machineConfig, labels)
 	c := fake.NewSimpleClientset(m).MachineV1beta1()


### PR DESCRIPTION
So all machines owned by a cluster are easily recognizable
without relying on instance name prefix/suffix.

```sh
$ az vm list -g jchaloup-njzl2-rg | jq '.[] | (.name) + "    " + (.tags|tostring)'
"jchaloup-njzl2-master-0    {}"
"jchaloup-njzl2-master-1    {}"
"jchaloup-njzl2-master-2    {}"
"jchaloup-njzl2-worker-centralus1-2hj5s    null"
"jchaloup-njzl2-worker-centralus1-5nndn    {\"kubernetes.io-cluster-jchaloup-njzl2\":\"owned\"}"
"jchaloup-njzl2-worker-centralus2-kj2md    null"
"jchaloup-njzl2-worker-centralus3-zcsd7    null"
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```