### PR TITLE
CLOUD-670: allow setting the security group and application security groups for machine in spec

### DIFF
--- a/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
@@ -56,6 +56,14 @@ type AzureMachineProviderSpec struct {
 	PublicIP     bool              `json:"publicIP"`
 	Tags         map[string]string `json:"tags,omitempty"`
 
+	// Network Security Group that needs to be attached to the machine's interface.
+	// No security group will be attached if empty.
+	SecurityGroup string `json:"securityGroup,omitempty"`
+
+	// Application Security Groups that need to be attached to the machine's interface.
+	// No application security groups will be attached if zero-length.
+	ApplicationSecurityGroups []string `json:"applicationSecurityGroups,omitempty"`
+
 	// Subnet to use for this instance
 	Subnet string `json:"subnet"`
 

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -498,6 +498,14 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 		networkInterfaceSpec.InternalLoadBalancerName = s.scope.MachineConfig.InternalLoadBalancer
 	}
 
+	if s.scope.MachineConfig.SecurityGroup != "" {
+		networkInterfaceSpec.SecurityGroupName = s.scope.MachineConfig.SecurityGroup
+	}
+
+	if len(s.scope.MachineConfig.ApplicationSecurityGroups) > 0 {
+		networkInterfaceSpec.ApplicationSecurityGroupNames = s.scope.MachineConfig.ApplicationSecurityGroups
+	}
+
 	if s.scope.MachineConfig.PublicIP {
 		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.Cluster.Name, s.scope.Machine.Name)
 		if err != nil {

--- a/pkg/cloud/azure/services/applicationsecuritygroups/applicationsecuritygroups.go
+++ b/pkg/cloud/azure/services/applicationsecuritygroups/applicationsecuritygroups.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationsecuritygroups
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
+)
+
+// Spec specification for network application security groups
+type Spec struct {
+	Name string
+}
+
+// Get provides information about a route table.
+func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error) {
+	asgSpec, ok := spec.(*Spec)
+	if !ok {
+		return network.ApplicationSecurityGroup{}, errors.New("invalid application security groups specification")
+	}
+	applicationSecurityGroup, err := s.Client.Get(ctx, s.Scope.ClusterConfig.ResourceGroup, asgSpec.Name)
+	if err != nil && azure.ResourceNotFound(err) {
+		return nil, errors.Wrapf(err, "application security group %s not found", asgSpec.Name)
+	} else if err != nil {
+		return applicationSecurityGroup, err
+	}
+	return applicationSecurityGroup, nil
+}
+
+// CreateOrUpdate creates or updates a route table.
+func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
+	asgSpec, ok := spec.(*Spec)
+	if !ok {
+		return errors.New("invalid application security groups specification")
+	}
+
+	klog.V(2).Infof("creating application security group %s", asgSpec.Name)
+	f, err := s.Client.CreateOrUpdate(
+		ctx,
+		s.Scope.ClusterConfig.ResourceGroup,
+		asgSpec.Name,
+		network.ApplicationSecurityGroup{
+			Location: to.StringPtr(s.Scope.ClusterConfig.Location),
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create application security group %s in resource group %s", asgSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
+	}
+
+	err = f.WaitForCompletionRef(ctx, s.Client.Client)
+	if err != nil {
+		return errors.Wrap(err, "cannot create, future response")
+	}
+
+	_, err = f.Result(s.Client)
+	if err != nil {
+		return errors.Wrap(err, "result error")
+	}
+	klog.V(2).Infof("created application security group %s", asgSpec.Name)
+	return err
+}
+
+// Delete deletes the route table with the provided name.
+func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
+	asgSpec, ok := spec.(*Spec)
+	if !ok {
+		return errors.New("invalid application security groups specification")
+	}
+	klog.V(2).Infof("deleting application security group %s", asgSpec.Name)
+	f, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.ResourceGroup, asgSpec.Name)
+	if err != nil && azure.ResourceNotFound(err) {
+		// already deleted
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete application security group %s in resource group %s", asgSpec.Name, s.Scope.ClusterConfig.ResourceGroup)
+	}
+
+	err = f.WaitForCompletionRef(ctx, s.Client.Client)
+	if err != nil {
+		return errors.Wrap(err, "cannot create, future response")
+	}
+
+	_, err = f.Result(s.Client)
+	if err != nil {
+		return err
+	}
+
+	klog.V(2).Infof("deleted application security group %s", asgSpec.Name)
+	return err
+}

--- a/pkg/cloud/azure/services/applicationsecuritygroups/service.go
+++ b/pkg/cloud/azure/services/applicationsecuritygroups/service.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationsecuritygroups
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators"
+)
+
+// Service provides operations on resource groups
+type Service struct {
+	Client network.ApplicationSecurityGroupsClient
+	Scope  *actuators.Scope
+}
+
+// getGroupsClient creates a new groups client from subscriptionid.
+func getApplicationSecurityGroupsClient(subscriptionID string, authorizer autorest.Authorizer) network.ApplicationSecurityGroupsClient {
+	applicationSecurityGroupsClient := network.NewApplicationSecurityGroupsClient(subscriptionID)
+	applicationSecurityGroupsClient.Authorizer = authorizer
+	applicationSecurityGroupsClient.AddToUserAgent(azure.UserAgent)
+	return applicationSecurityGroupsClient
+}
+
+// NewService creates a new groups service.
+func NewService(scope *actuators.Scope) azure.Service {
+	return &Service{
+		Client: getApplicationSecurityGroupsClient(scope.SubscriptionID, scope.Authorizer),
+		Scope:  scope,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the machine spec to allow setting the security group and application security groups for machine

Firewall on Azure is controlled by network security groups. NSGs can be attached at the subnet level or can be attached to individual network interfaces.

attaching the NSG to subnets allows controlling firewall for all resources in the subnet, but only *ONE* NSG can be attached to a subnet. The lack of composition is especially bad for openshift installer when users want to install the cluster to some pre-existing subnets. 
The installer cannot create isolation boundaries for the cluster from other resources in the same subnet as the installer cannot update the subnet level NSG as that is not appropriate for shared subnet.

attaching the NSG to individual machines allows controlling the firewall for machines of a cluster, similar to how it is done on AWS (attaching security groups to machines) or GCP (source destination tags attached to the machines).
This allows the installer to control the isolation boundaries for the cluster in a shared subnet.

**Special notes for your reviewer**:

The network security group is in the same location and resource group as the machine, and each application security group is also in the same location and
resource group as the machine.


```release-note
Adds securityGroup and applicationSecurityGroups fields to the machine spec
```