### PR TITLE
UPSTREAM: <carry>: openshift: services/networkinterfaces: fix application security group collection

### DIFF
--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -158,7 +158,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	if len(nicSpec.ApplicationSecurityGroupNames) > 0 {
 		asgSvc := applicationsecuritygroups.NewService(s.Scope)
 
-		groups := make([]network.ApplicationSecurityGroup, len(nicSpec.ApplicationSecurityGroupNames))
+		var groups []network.ApplicationSecurityGroup
 		for _, asgName := range nicSpec.ApplicationSecurityGroupNames {
 			asgInterface, asgerr := asgSvc.Get(ctx, &applicationsecuritygroups.Spec{Name: asgName})
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previosly (https://github.com/openshift/cluster-api-provider-azure/commit/d1d0550184fc223cffae172623e856415ae2f4cd#diff-163ea357c91ff9f422b314e3b60e84f7R161-R173), the groups ID slice was initialized to the len to ASG names, and then append was used to add ASG IDs, which causes the group ID slice to contain empty IDs and then appended required IDs.

The fix initializes the group ID slice to empty to correctly append.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```