### PR TITLE
Environment: Adding support for dynamic environment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.7.0
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
-	github.com/coreos/etcd v3.3.15+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.3.1
 	github.com/openshift/machine-api-operator v0.2.1-0.20191128180243-986b771e661d

--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -53,6 +53,8 @@ const (
 	AzureCredsRegionKey = "azure_region"
 	// AzureResourcePrefix resource prefix for created azure resources
 	AzureResourcePrefix = "azure_resource_prefix"
+	// Azure Environment
+	AzureEnvironmentKey = "azure_env"
 )
 
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
@@ -297,11 +299,19 @@ func updateScope(coreClient controllerclient.Client, credentialsSecret *apicorev
 		return errors.Errorf("Azure resource prefix %v did not contain key %v",
 			secretType.String(), AzureResourcePrefix)
 	}
+	envName := []byte("")
+	envName, ok = secret.Data[AzureEnvironmentKey]
+	if !ok {
+		envName = []byte("AzurePublicCloud")
+		return errors.Errorf("Azure Envrionment %v did not contain key %v",
+			secretType.String(), AzureEnvironmentKey)
+	}
 
-	env, err := azure.EnvironmentFromName("AzurePublicCloud")
+	env, err := azure.EnvironmentFromName(string(envName))
 	if err != nil {
 		return err
 	}
+
 	oauthConfig, err := adal.NewOAuthConfig(
 		env.ActiveDirectoryEndpoint, string(tenantID))
 	if err != nil {


### PR DESCRIPTION
Allows environment to be pulled from secret, work around if secret value doesn't exist

**What this PR does / why we need it**:

Gets the azure environment from the cloud provider secret, this allows actuator to target azure subscriptions not in the public cloud. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Looks for azure_env key in the cloud provider secret and targets azure sdk towards that environment.
```