### PR TITLE
Bug 1796599: Save status before Patch()

### DIFF
--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -189,11 +189,15 @@ func (m *MachineScope) setMachineStatus() error {
 func (m *MachineScope) PatchMachine() error {
 	klog.V(3).Infof("%v: patching machine", m.Machine.GetName())
 
+	statusCopy := *m.Machine.Status.DeepCopy()
+
 	// patch machine
 	if err := m.CoreClient.Patch(context.Background(), m.Machine, m.machineToBePatched); err != nil {
 		klog.Errorf("Failed to patch machine %q: %v", m.Machine.GetName(), err)
 		return err
 	}
+
+	m.Machine.Status = statusCopy
 
 	// patch status
 	if err := m.CoreClient.Status().Patch(context.Background(), m.Machine, m.machineToBePatched); err != nil {


### PR DESCRIPTION
Currently, the actual status never gets updated. First `Patch()` call updates machine, but doesn't update the status, which means that status remains outdated. The result of the first `Patch()` call is an updated machine with an outdated status. This result is saved to `machine` that we pass as an argument. When we call `Status().Patch()` later with the same machine, actual status never gets there.
The solution is to save status, before calling first `Patch()`
