### PR TITLE
Bug 1809001: Remove fqdn from public ip creation

### DIFF
--- a/pkg/cloud/azure/services/publicips/publicips.go
+++ b/pkg/cloud/azure/services/publicips/publicips.go
@@ -70,7 +70,6 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 				PublicIPAllocationMethod: network.Static,
 				DNSSettings: &network.PublicIPAddressDNSSettings{
 					DomainNameLabel: to.StringPtr(strings.ToLower(ipName)),
-					Fqdn:            to.StringPtr(s.Scope.Network().APIServerIP.DNSName),
 				},
 			},
 		},


### PR DESCRIPTION
Remove fqdn from public ip creation. `s.Scope.Network()` always returns nil and this caused panic.
 I will open a followup PR that removes unused code.