### PR TITLE
UPSTREAM: <carry>: openshift: Bump to Go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 as builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-azure

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ifeq ($(NO_DOCKER), 1)
   IMAGE_BUILD_CMD = imagebuilder
   CGO_ENABLED = 1
 else
-  DOCKER_CMD := docker run --rm -e CGO_ENABLED=1 -v "$(PWD)":/go/src/sigs.k8s.io/cluster-api-provider-azure:Z -w /go/src/sigs.k8s.io/cluster-api-provider-azure openshift/origin-release:golang-1.12
+  DOCKER_CMD := docker run --rm -e CGO_ENABLED=1 -v "$(PWD)":/go/src/sigs.k8s.io/cluster-api-provider-azure:Z -w /go/src/sigs.k8s.io/cluster-api-provider-azure openshift/origin-release:golang-1.13
   IMAGE_BUILD_CMD = docker build
 endif
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-azure
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go v32.5.0+incompatible

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -14,6 +14,6 @@ else
     --env GOPROXY="$GOPROXY" \
     --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
     --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
-    openshift/origin-release:golang-1.12 \
+    openshift/origin-release:golang-1.13 \
     ./hack/goimports.sh "${@}"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump scripts and docker images to Go 1.13