### PR TITLE
Bug 1828288: UPSTREAM: <carry>: openshift: Deprecate machine.openshift.io/memoryMb annotation in favour of machine.openshift.io/memory

### DIFF
--- a/pkg/cloud/azure/actuators/machineset/controller.go
+++ b/pkg/cloud/azure/actuators/machineset/controller.go
@@ -37,7 +37,7 @@ const (
 	// This is needed by the autoscaler to foresee upcoming capacity when scaling from zero.
 	// https://github.com/openshift/enhancements/pull/186
 	cpuKey    = "machine.openshift.io/vCPU"
-	memoryKey = "machine.openshift.io/memoryMb"
+	memoryKey = "machine.openshift.io/memory"
 	gpuKey    = "machine.openshift.io/GPU"
 )
 
@@ -136,7 +136,8 @@ func reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, error) {
 
 	// TODO: get annotations keys from machine API
 	machineSet.Annotations[cpuKey] = strconv.FormatInt(instanceType.VCPU, 10)
-	machineSet.Annotations[memoryKey] = strconv.FormatInt(instanceType.MemoryMb, 10)
+	// See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+	machineSet.Annotations[memoryKey] = fmt.Sprintf("%sM", strconv.FormatInt(instanceType.MemoryMb, 10))
 	machineSet.Annotations[gpuKey] = strconv.FormatInt(instanceType.GPU, 10)
 
 	return ctrl.Result{}, nil

--- a/pkg/cloud/azure/actuators/machineset/controller_test.go
+++ b/pkg/cloud/azure/actuators/machineset/controller_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Reconciler", func() {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "4",
-				memoryKey: "16384",
+				memoryKey: "16384M",
 				gpuKey:    "0",
 			},
 			expectedEvents: []string{},
@@ -125,7 +125,7 @@ var _ = Describe("Reconciler", func() {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "24",
-				memoryKey: "229376",
+				memoryKey: "229376M",
 				gpuKey:    "4",
 			},
 			expectedEvents: []string{},
@@ -140,7 +140,7 @@ var _ = Describe("Reconciler", func() {
 				"existing": "annotation",
 				"annother": "existingAnnotation",
 				cpuKey:     "24",
-				memoryKey:  "229376",
+				memoryKey:  "229376M",
 				gpuKey:     "4",
 			},
 			expectedEvents: []string{},
@@ -210,7 +210,7 @@ func TestReconcile(t *testing.T) {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "4",
-				memoryKey: "16384",
+				memoryKey: "16384M",
 				gpuKey:    "0",
 			},
 			expectErr: false,
@@ -221,7 +221,7 @@ func TestReconcile(t *testing.T) {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "24",
-				memoryKey: "229376",
+				memoryKey: "229376M",
 				gpuKey:    "4",
 			},
 			expectErr: false,
@@ -237,7 +237,7 @@ func TestReconcile(t *testing.T) {
 				"existing": "annotation",
 				"annother": "existingAnnotation",
 				cpuKey:     "24",
-				memoryKey:  "229376",
+				memoryKey:  "229376M",
 				gpuKey:     "4",
 			},
 			expectErr: false,


### PR DESCRIPTION
Cluster autoscaler and aws/gcp/azure controllers should drop the "machine.openshift.io/memoryMb" deprecated annotation and use only "machine.openshift.io/memory".

This way controllers are responsible to set the unit format according to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory while the autoscaler should be able to read it appropiately.
This is more robust and practical than the current approach and assumptions.
https://bugzilla.redhat.com/show_bug.cgi?id=1828288

Needs openshift/kubernetes-autoscaler#145
/hold