### PR TITLE
[release-4.4] Bug 1810531: UPSTREAM: <carry>: openshift: Revendor MAO with timeout formatting fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.3.1
-	github.com/openshift/machine-api-operator v0.2.1-0.20200212112539-a9085e24cf62
+	github.com/openshift/machine-api-operator v0.2.1-0.20200324201140-3327b0f6293e
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
@@ -19,6 +19,7 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/kubectl v0.0.0-20200124035537-9f7d91504e51
 	k8s.io/utils v0.0.0-20191217005138-9e5e9d854fcc
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/controller-tools v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/openshift/api v0.0.0-20200127192224-ffde1bfabb9f/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20190617165122-8892c0adc000/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
-github.com/openshift/machine-api-operator v0.2.1-0.20200212112539-a9085e24cf62 h1:tVWVyRf853rW/qduUEENiPAOGeEUBxVki7hmPEuvfu4=
-github.com/openshift/machine-api-operator v0.2.1-0.20200212112539-a9085e24cf62/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=
+github.com/openshift/machine-api-operator v0.2.1-0.20200324201140-3327b0f6293e h1:XroPkdWaMAehv5gDpe410JOhZmkSp1++iyvHIxFlwYM=
+github.com/openshift/machine-api-operator v0.2.1-0.20200324201140-3327b0f6293e/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
@@ -358,7 +358,7 @@ func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
 	}
 
 	if nodeIsUnreachable(node) {
-		klog.Infof("%q: Node %q is unreachable, draining will wait %q seconds after pod is signalled for deletion and skip after it",
+		klog.Infof("%q: Node %q is unreachable, draining will wait %d seconds after pod is signalled for deletion and skip after it",
 			machine.Name, node.Name, skipWaitForDeleteTimeoutSeconds)
 		drainer.SkipWaitForDeleteTimeoutSeconds = skipWaitForDeleteTimeoutSeconds
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openshift/machine-api-operator v0.2.1-0.20200212112539-a9085e24cf62
+# github.com/openshift/machine-api-operator v0.2.1-0.20200324201140-3327b0f6293e
 github.com/openshift/machine-api-operator/cmd/machineset
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1


### PR DESCRIPTION
Revendor MAO with timeout formatting fix in node draining log message.