### PR TITLE
Fix confusing log in azure

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -198,7 +198,7 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error
 
 // Exists test for the existence of a machine and is invoked by the Machine Controller
 func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool, error) {
-	klog.Infof("Checking if machine %v exists", machine.Name)
+	klog.Infof("%s: actuator checking if machine exists", machine.GetName())
 
 	scope, err := actuators.NewMachineScope(actuators.MachineScopeParams{
 		Machine:    machine,

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -350,8 +350,6 @@ func (s *Reconciler) Exists(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("returned incorrect vm interface: %T", vmInterface)
 	}
 
-	klog.Infof("Found vm for machine %s", s.scope.Name())
-
 	if s.scope.MachineConfig.UserDataSecret == nil {
 		vmExtSpec := &virtualmachineextensions.Spec{
 			Name:   "startupScript",
@@ -374,8 +372,11 @@ func (s *Reconciler) Exists(ctx context.Context) (bool, error) {
 	case v1beta1.VMStateUpdating:
 		klog.Infof("Machine %v is updating", to.String(vm.VMID))
 	default:
+		klog.Infof("Not found vm for machine %s", s.scope.Machine.GetName())
 		return false, nil
 	}
+
+	klog.Infof("Found vm for machine %s", s.scope.Machine.GetName())
 
 	return true, nil
 }


### PR DESCRIPTION
We log `found vm for machine ...` when `Exists()` can return false. This PR should fix that.