### PR TITLE
Bug 1837341: Use ToLower for Subscription ID and Resource Group Name

### DIFF
--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -108,10 +109,13 @@ func GenerateManagedIdentityName(subscriptionID, resourceGroupName, managedIdent
 // GenerateMachineProviderID generates machine provider id.
 func GenerateMachineProviderID(subscriptionID, resourceGroupName, machineName string) string {
 	// From https://github.com/kubernetes/kubernetes/blob/e09f5c40b55c91f681a46ee17f9bc447eeacee57/pkg/cloudprovider/providers/azure/azure_standard.go#L68-L75
+
+	// Convert subscriptionID and resourceGroupName to lowercase to match the ID the legacy cloud provider sets on the Node
+	// Ref: https://github.com/kubernetes/legacy-cloud-providers/blob/2c79b47a93724ada71ae2d311d3cd9dcdab3c415/azure/azure_instances.go#L375-L377
 	return fmt.Sprintf(
 		"azure:///subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
-		subscriptionID,
-		resourceGroupName,
+		strings.ToLower(subscriptionID),
+		strings.ToLower(resourceGroupName),
 		machineName)
 }
 

--- a/pkg/cloud/azure/defaults_test.go
+++ b/pkg/cloud/azure/defaults_test.go
@@ -39,3 +39,37 @@ func TestGenerateMachinePublicIPName(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateMachineProviderID(t *testing.T) {
+	testCases := []struct {
+		name              string
+		subscriptionID    string
+		resourceGroupName string
+		machineName       string
+		expectedID        string
+	}{
+		{
+			name:              "with all lower case strings",
+			subscriptionID:    "test-subscription-id",
+			resourceGroupName: "test-resource-group",
+			machineName:       "test-machine",
+			expectedID:        "azure:///subscriptions/test-subscription-id/resourceGroups/test-resource-group/providers/Microsoft.Compute/virtualMachines/test-machine",
+		},
+		{
+			name:              "with capitals, lower cases subsciption id and resource group name",
+			subscriptionID:    "Test-Upper-SUBSCRIPTION-Id",
+			resourceGroupName: "Test-Upper-RESOURCE-GROUP",
+			machineName:       "Test-MACHINE",
+			expectedID:        "azure:///subscriptions/test-upper-subscription-id/resourceGroups/test-upper-resource-group/providers/Microsoft.Compute/virtualMachines/Test-MACHINE",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := GenerateMachineProviderID(tc.subscriptionID, tc.resourceGroupName, tc.machineName)
+			if id != tc.expectedID {
+				t.Errorf("Expected Id: %s, Got Id: %s", tc.expectedID, id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When setting the ProviderID for a Machine, this sets the subscriptionID and the resourceGroupName to lowercase strings as in done in the upstream legacy-cloud-provider which sets ProviderIDs on Nodes.

This fixes an issue where users could configure their MachineSet with a capitalised resourceGroup (even though the API is case-insensitive) and then the ProviderID  on the Machine would not match the ProviderID on the Node, causing the autoscaler to believe the instance was unregistered