### PR TITLE
[release-4.4] Bug 1841478: Use ToLower for Subscription ID and Resource Group Name

### DIFF
--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package azure
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	// DefaultUserName is the default username for created vm
@@ -105,10 +108,13 @@ func GenerateManagedIdentityName(subscriptionID, resourceGroupName, managedIdent
 // GenerateMachineProviderID generates machine provider id.
 func GenerateMachineProviderID(subscriptionID, resourceGroupName, machineName string) string {
 	// From https://github.com/kubernetes/kubernetes/blob/e09f5c40b55c91f681a46ee17f9bc447eeacee57/pkg/cloudprovider/providers/azure/azure_standard.go#L68-L75
+
+	// Convert subscriptionID and resourceGroupName to lowercase to match the ID the legacy cloud provider sets on the Node
+	// Ref: https://github.com/kubernetes/legacy-cloud-providers/blob/2c79b47a93724ada71ae2d311d3cd9dcdab3c415/azure/azure_instances.go#L375-L377
 	return fmt.Sprintf(
 		"azure:///subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
-		subscriptionID,
-		resourceGroupName,
+		strings.ToLower(subscriptionID),
+		strings.ToLower(resourceGroupName),
 		machineName)
 }
 

--- a/pkg/cloud/azure/defaults_test.go
+++ b/pkg/cloud/azure/defaults_test.go
@@ -39,3 +39,37 @@ func TestGenerateMachinePublicIPName(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateMachineProviderID(t *testing.T) {
+	testCases := []struct {
+		name              string
+		subscriptionID    string
+		resourceGroupName string
+		machineName       string
+		expectedID        string
+	}{
+		{
+			name:              "with all lower case strings",
+			subscriptionID:    "test-subscription-id",
+			resourceGroupName: "test-resource-group",
+			machineName:       "test-machine",
+			expectedID:        "azure:///subscriptions/test-subscription-id/resourceGroups/test-resource-group/providers/Microsoft.Compute/virtualMachines/test-machine",
+		},
+		{
+			name:              "with capitals, lower cases subsciption id and resource group name",
+			subscriptionID:    "Test-Upper-SUBSCRIPTION-Id",
+			resourceGroupName: "Test-Upper-RESOURCE-GROUP",
+			machineName:       "Test-MACHINE",
+			expectedID:        "azure:///subscriptions/test-upper-subscription-id/resourceGroups/test-upper-resource-group/providers/Microsoft.Compute/virtualMachines/Test-MACHINE",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := GenerateMachineProviderID(tc.subscriptionID, tc.resourceGroupName, tc.machineName)
+			if id != tc.expectedID {
+				t.Errorf("Expected Id: %s, Got Id: %s", tc.expectedID, id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cheery-pick of #134 onto the release-4.4 branch