### PR TITLE
Expose spot instances to provider spec and reconcile label

### DIFF
--- a/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
@@ -88,6 +88,15 @@ type AzureMachineProviderSpec struct {
 
 	NetworkResourceGroup string `json:"networkResourceGroup,omitempty"`
 	ResourceGroup        string `json:"resourceGroup,omitempty"`
+
+	// SpotVMOptions allows the ability to specify the Machine should use a Spot VM
+	SpotVMOptions *SpotVMOptions `json:"spotVMOptions,omitempty"`
+}
+
+// SpotVMOptions defines the options relevant to running the Machine on Spot VMs
+type SpotVMOptions struct {
+	// MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
+	MaxPrice *string `json:"maxPrice,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -328,6 +328,10 @@ func (s *Reconciler) setMachineCloudProviderSpecifics(vm compute.VirtualMachine)
 	if vm.Zones != nil {
 		s.scope.Machine.Labels[MachineAZLabelName] = strings.Join(*vm.Zones, ",")
 	}
+
+	if s.scope.MachineConfig.SpotVMOptions != nil {
+		s.scope.Machine.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
+	}
 }
 
 // Exists checks if machine exists

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	machineapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
@@ -450,7 +450,7 @@ func (s *Reconciler) getZone(ctx context.Context) (string, error) {
 
 func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string) error {
 	if s.scope.MachineConfig.Vnet == "" {
-		return machineapierrors.InvalidMachineConfiguration("MachineConfig vnet is missing on machine %s", s.scope.Machine.Name)
+		return machinecontroller.InvalidMachineConfiguration("MachineConfig vnet is missing on machine %s", s.scope.Machine.Name)
 	}
 
 	networkInterfaceSpec := &networkinterfaces.Spec{
@@ -459,7 +459,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 	}
 
 	if s.scope.MachineConfig.Subnet == "" {
-		return machineapierrors.InvalidMachineConfiguration("MachineConfig subnet is missing on machine %s, skipping machine creation", s.scope.Machine.Name)
+		return machinecontroller.InvalidMachineConfiguration("MachineConfig subnet is missing on machine %s, skipping machine creation", s.scope.Machine.Name)
 	}
 
 	networkInterfaceSpec.SubnetName = s.scope.MachineConfig.Subnet
@@ -485,7 +485,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 	if s.scope.MachineConfig.PublicIP {
 		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.MachineConfig.Name, s.scope.Machine.Name)
 		if err != nil {
-			return machineapierrors.InvalidMachineConfiguration("unable to create Public IP: %v", err)
+			return machinecontroller.InvalidMachineConfiguration("unable to create Public IP: %v", err)
 		}
 		err = s.publicIPSvc.CreateOrUpdate(ctx, &publicips.Spec{Name: publicIPName})
 		if err != nil {


### PR DESCRIPTION
Start introducing spot instances to downstream by exposing them to provider spec and reconciling label

https://raw.githubusercontent.com/openshift/enhancements/master/enhancements/machine-api/spot-instances.md