### PR TITLE
Add termination handler for spot instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,4 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ./machine-controller-ma
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-azure/machine-controller-manager .
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-azure/bin/termination-handler .

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ test-e2e:
 build: ## build binaries
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/machine-controller-manager" \
                -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/manager"
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/termination-handler" \
+               -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/termination-handler"
 
 .PHONY: test
 test: ## Run tests

--- a/cmd/termination-handler/main.go
+++ b/cmd/termination-handler/main.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/termination"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	logger := klogr.New()
+
+	pollIntervalSeconds := flag.Int64("poll-interval-seconds", 5, "interval in seconds at which termination notice endpoint should be checked (Default: 5)")
+	nodeName := flag.String("node-name", "", "name of the node that the termination handler is running on")
+	namespace := flag.String("namespace", "", "namespace that the machine for the node should live in. If unspecified, look for machines across all namespaces.")
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		klog.Fatalf("Error getting configuration: %v", err)
+	}
+
+	// Get the poll interval as a duration from the `poll-interval-seconds` flag
+	pollInterval := time.Duration(*pollIntervalSeconds) * time.Second
+
+	// Construct a termination handler
+	handler, err := termination.NewHandler(logger, cfg, pollInterval, *namespace, *nodeName)
+	if err != nil {
+		klog.Fatalf("Error constructing termination handler: %v", err)
+	}
+
+	// Start the termination handler
+	if err := handler.Run(ctrl.SetupSignalHandler()); err != nil {
+		klog.Fatalf("Error starting termination handler: %v", err)
+	}
+}

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -331,7 +331,10 @@ func (s *Reconciler) setMachineCloudProviderSpecifics(vm compute.VirtualMachine)
 	}
 
 	if s.scope.MachineConfig.SpotVMOptions != nil {
-		s.scope.Machine.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
+		if s.scope.Machine.Spec.Labels == nil {
+			s.scope.Machine.Spec.Labels = make(map[string]string)
+		}
+		s.scope.Machine.Spec.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
 	}
 }
 

--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -1,0 +1,201 @@
+package termination
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// azureTerminationEndpointURL see the following link for more details about the endpoint
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#endpoint-discovery
+	azureTerminationEndpointURL = "http://169.254.169.254/metadata/scheduledevents?api-version=2019-08-01"
+)
+
+// Handler represents a handler that will run to check the termination
+// notice endpoint and delete Machine's if the instance termination notice is fulfilled.
+type Handler interface {
+	Run(stop <-chan struct{}) error
+}
+
+// NewHandler constructs a new Handler
+func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, namespace, nodeName string) (Handler, error) {
+	machinev1.AddToScheme(scheme.Scheme)
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %v", err)
+	}
+
+	pollURL, err := url.Parse(azureTerminationEndpointURL)
+	if err != nil {
+		// This should never happen
+		panic(err)
+	}
+
+	logger = logger.WithValues("node", nodeName, "namespace", namespace)
+
+	return &handler{
+		client:       c,
+		pollURL:      pollURL,
+		pollInterval: pollInterval,
+		nodeName:     nodeName,
+		namespace:    namespace,
+		log:          logger,
+	}, nil
+}
+
+// handler implements the logic to check the termination endpoint and delete the
+// machine associated with the node
+type handler struct {
+	client       client.Client
+	pollURL      *url.URL
+	pollInterval time.Duration
+	nodeName     string
+	namespace    string
+	log          logr.Logger
+}
+
+// Run starts the handler and runs the termination logic
+func (h *handler) Run(stop <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errs := make(chan error, 1)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		errs <- h.run(ctx)
+	}()
+
+	select {
+	case <-stop:
+		cancel()
+		// Wait for run to stop
+		wg.Wait()
+		return nil
+	case err := <-errs:
+		cancel()
+		return err
+	}
+}
+
+func (h *handler) run(ctx context.Context) error {
+	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
+		req, err := http.NewRequest("GET", h.pollURL.String(), nil)
+		if err != nil {
+			return false, fmt.Errorf("could not create request %q: %w", h.pollURL.String(), err)
+		}
+
+		req.Header.Add("Metadata", "true")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("could not get URL %q: %w", h.pollURL.String(), err)
+		}
+
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read responce body: %w", err)
+		}
+
+		s := scheduledEvents{}
+		err = json.Unmarshal(bodyBytes, &s)
+		if err != nil {
+			return false, fmt.Errorf("failed to unmarshal responce body: %w", err)
+		}
+
+		for _, event := range s.Events {
+			if event.EventType == preemptEventType {
+				// Instance marked for termination
+				return true, nil
+			}
+		}
+
+		// Instance not terminated yet
+		h.log.V(2).Info("Instance not marked for termination")
+		return false, nil
+	}, ctx.Done()); err != nil {
+		return fmt.Errorf("error polling termination endpoint: %w", err)
+	}
+
+	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
+		h.log.V(1).Info("Getting node for machine")
+		machine, err := h.getMachineForNode(ctx)
+		if err != nil {
+			if errors.Is(err, notFoundMachineForNode{}) {
+				h.log.Error(err, "Machine not found for node")
+				return true, nil
+			}
+			h.log.Error(err, "error fetching machine for node:", h.nodeName)
+			return false, nil
+		}
+
+		// Will only get here if the termination endpoint returned FALSE
+		h.log.Info("Instance marked for termination, deleting Machine")
+		if err := h.client.Delete(ctx, machine); err != nil {
+			if apierrors.IsNotFound(err) {
+				h.log.Error(err, "Machine not found when deleting")
+				return true, nil
+			}
+			h.log.Error(err, "Error deleting machine")
+			return false, nil
+		}
+
+		return true, nil
+	}, ctx.Done()); err != nil {
+		return fmt.Errorf("error getting and deleting machine: %w", err)
+	}
+
+	return nil
+}
+
+// getMachineForNodeName finds the Machine associated with the Node name given
+func (h *handler) getMachineForNode(ctx context.Context) (*machinev1.Machine, error) {
+	machineList := &machinev1.MachineList{}
+	err := h.client.List(ctx, machineList, client.InNamespace(h.namespace))
+	if err != nil {
+		return nil, fmt.Errorf("error listing machines: %w", err)
+	}
+
+	for _, machine := range machineList.Items {
+		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == h.nodeName {
+			return &machine, nil
+		}
+	}
+
+	return nil, notFoundMachineForNode{}
+}
+
+const preemptEventType = "Preempt"
+
+// scheduledEvents represents metadata response, more detailed info can be found here:
+// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events#use-the-api
+type scheduledEvents struct {
+	Events []events `json:"Events"`
+}
+
+type events struct {
+	EventType string `json:"EventType"`
+}
+
+// notFoundMachineForNode this error is returned when no machine for node is found in a list of machines
+type notFoundMachineForNode struct{}
+
+func (err notFoundMachineForNode) Error() string {
+	return "machine not found for node"
+}

--- a/pkg/termination/termination_suite_test.go
+++ b/pkg/termination/termination_suite_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+const (
+	timeout       = 10 * time.Second
+	testNamespace = "test-namespace"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+
+	ctx = context.Background()
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Termination Handler Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crds")},
+	}
+
+	// Use our own scheme so we don't interfere with any test cases
+	// that would initialise the scheme themselves.
+	scheme := runtime.NewScheme()
+	kubernetesscheme.AddToScheme(scheme)
+	machinev1.AddToScheme(scheme)
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNamespace,
+		},
+	})).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// StartTestHandler starts the test handler
+func StartTestHandler(th Handler) (chan struct{}, chan error) {
+	stop := make(chan struct{})
+	errs := make(chan error)
+	go func() {
+		errs <- th.Run(stop)
+	}()
+	return stop, errs
+}

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var emptyEvents = func(rw http.ResponseWriter, req *http.Request) {
+	rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
+}
+
+var _ = Describe("Handler Suite", func() {
+	var terminationServer *httptest.Server
+	var httpHandler http.Handler
+	var nodeName string
+	var stop chan struct{}
+	var errs chan error
+	var h *handler
+
+	BeforeEach(func() {
+		// Reset test vars
+		terminationServer = nil
+		httpHandler = nil
+		nodeName = "test-node"
+		httpHandler = newMockHTTPHandler(emptyEvents)
+		stop = nil
+		errs = nil
+
+		// use NewHandler() instead of manual construction in order to test NewHandler() logic
+		// like checking that machine api is added to scheme
+		handlerInterface, err := NewHandler(klogr.New(), cfg, 100*time.Millisecond, "", nodeName)
+		Expect(err).ToNot(HaveOccurred())
+
+		h = handlerInterface.(*handler)
+
+		// set pollURL so we can override initial value later
+		h.pollURL = nil
+	})
+
+	JustBeforeEach(func() {
+		Expect(httpHandler).ToNot(BeNil())
+		terminationServer = httptest.NewServer(httpHandler)
+
+		if h.pollURL == nil {
+			pollURL, err := url.Parse(terminationServer.URL)
+			Expect(err).ToNot(HaveOccurred())
+			h.pollURL = pollURL
+		}
+	})
+
+	AfterEach(func() {
+		if stop != nil && !isClosed(stop) {
+			close(stop)
+		}
+		terminationServer.Close()
+
+		Expect(deleteAllMachines(k8sClient)).To(Succeed())
+	})
+
+	Context("when running the handler", func() {
+		JustBeforeEach(func() {
+			stop, errs = StartTestHandler(h)
+		})
+
+		Context("when the handler is stopped", func() {
+			JustBeforeEach(func() {
+				close(stop)
+			})
+
+			It("should not return an error", func() {
+				Eventually(errs).Should(Receive(BeNil()))
+			})
+		})
+
+		Context("when no machine exists for the node", func() {
+			It("should not receive an error upon starting", func() {
+				Consistently(errs).ShouldNot(Receive())
+			})
+		})
+
+		Context("when a machine exists for the node", func() {
+			var counter int32
+			var testMachine *machinev1.Machine
+
+			BeforeEach(func() {
+				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
+				createMachine(testMachine)
+
+				// Ensure the polling logic is excercised in tests
+				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+					if atomic.LoadInt32(&counter) == 4 {
+						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[{"EventType":"Preempt", "ResourceType": "VirtualMachine"}]}`))
+					} else {
+						atomic.AddInt32(&counter, 1)
+						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
+					}
+				})
+			})
+
+			JustBeforeEach(func() {
+				// Ensure the polling logic is excercised in tests
+				for atomic.LoadInt32(&counter) < 4 {
+					continue
+				}
+			})
+
+			Context("and the handler is stopped", func() {
+				JustBeforeEach(func() {
+					close(stop)
+				})
+
+				It("should not return an error", func() {
+					Eventually(errs).Should(Receive(BeNil()))
+				})
+
+				It("should not delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Consistently(func() error {
+						m := &machinev1.Machine{}
+						return k8sClient.Get(ctx, key, m)
+					}).Should(Succeed())
+				})
+			})
+
+			Context("and the instance termination notice is fulfilled", func() {
+				It("should delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Eventually(func() error {
+						m := &machinev1.Machine{}
+						err := k8sClient.Get(ctx, key, m)
+						if err != nil && errors.IsNotFound(err) {
+							return nil
+						} else if err != nil {
+							return err
+						}
+						return fmt.Errorf("machine not yet deleted")
+					}).Should(Succeed())
+				})
+			})
+
+			Context("and the instance termination notice is not fulfilled", func() {
+				BeforeEach(func() {
+					httpHandler = newMockHTTPHandler(emptyEvents)
+				})
+
+				It("should not delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Consistently(func() error {
+						m := &machinev1.Machine{}
+						return k8sClient.Get(ctx, key, m)
+					}).Should(Succeed())
+				})
+			})
+
+			Context("and the poll URL cannot be reached", func() {
+				BeforeEach(func() {
+					h.pollURL = &url.URL{Opaque: "abc#1://localhost"}
+				})
+
+				It("should return an error", func() {
+					Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
+				})
+
+				It("should not delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Consistently(func() error {
+						m := &machinev1.Machine{}
+						return k8sClient.Get(ctx, key, m)
+					}).Should(Succeed())
+				})
+			})
+		})
+	})
+
+	Context("getMachineForNode", func() {
+		var machine *machinev1.Machine
+		var err error
+
+		JustBeforeEach(func() {
+			machine, err = h.getMachineForNode(ctx)
+		})
+
+		Context("with a broken client", func() {
+			BeforeEach(func() {
+				brokenClient, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
+				Expect(err).ToNot(HaveOccurred())
+				h.client = brokenClient
+			})
+
+			It("should return an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("error listing machines: no kind is registered for the type v1beta1.MachineList in scheme"))
+			})
+
+			It("should not return a machine", func() {
+				Expect(machine).To(BeNil())
+			})
+		})
+
+		Context("with no machine for the node name", func() {
+			It("should return an error", func() {
+				Expect(err).To(MatchError(notFoundMachineForNode{}))
+			})
+
+			It("should not return a machine", func() {
+				Expect(machine).To(BeNil())
+			})
+		})
+
+		Context("with a machine matching the node name", func() {
+			var testMachine *machinev1.Machine
+
+			BeforeEach(func() {
+				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
+				createMachine(testMachine)
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return a machine", func() {
+				Expect(machine).To(Equal(testMachine))
+			})
+		})
+	})
+})
+
+var _ = Describe("ScheduledEvents Suite", func() {
+	Context("ummarshalling from json", func() {
+		var s *scheduledEvents
+		jsonData := []byte(`
+    {
+      "DocumentIncarnation":0,
+      "Events": [
+                {
+                  "EventType":"Preempt", 
+                  "ResourceType": "VirtualMachine"
+                },
+                {
+                  "EventType":"Preempt", 
+                  "ResourceType": "Terminate"
+                }
+      ]
+		}`)
+
+		BeforeEach(func() {
+			s = &scheduledEvents{}
+			Expect(json.Unmarshal(jsonData, s)).To(Succeed())
+		})
+
+		It("number of events to be equal to 2", func() {
+			Expect(len(s.Events)).To(Equal(2))
+		})
+
+		It("first event to have event type Preempt", func() {
+			Expect(s.Events[0].EventType).To(Equal(preemptEventType))
+		})
+	})
+})
+
+// mockHTTPHandler is used to mock the pollURL responses during tests
+type mockHTTPHandler struct {
+	handleFunc func(rw http.ResponseWriter, req *http.Request)
+}
+
+// ServeHTTP implements the http.Handler interface
+func (m *mockHTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	m.handleFunc(rw, req)
+}
+
+// newMockHTTPHandler constructs a mockHTTPHandler with the given handleFunc
+func newMockHTTPHandler(handleFunc func(http.ResponseWriter, *http.Request)) http.Handler {
+	return &mockHTTPHandler{handleFunc: handleFunc}
+}
+
+// isClosed checks if a channel is closed already
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
+}
+
+func deleteAllMachines(c client.Client) error {
+	machineList := &machinev1.MachineList{}
+	err := c.List(ctx, machineList)
+	if err != nil {
+		return fmt.Errorf("error listing machines: %v", err)
+	}
+
+	// Delete all machines found
+	for _, machine := range machineList.Items {
+		m := machine
+		err := c.Delete(ctx, &m)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newTestMachine(name, namespace, nodeName string) *machinev1.Machine {
+	return &machinev1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: machinev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: machinev1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: nodeName,
+			},
+		},
+	}
+}
+
+func createMachine(m *machinev1.Machine) {
+	typeMeta := m.TypeMeta
+	status := m.Status
+	Expect(k8sClient.Create(ctx, m)).To(Succeed())
+	m.Status = status
+	Expect(k8sClient.Status().Update(ctx, m)).To(Succeed())
+
+	// Fetch object to sync back to latest changes
+	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
+	Expect(k8sClient.Get(ctx, key, m)).To(Succeed())
+	// Restore TypeMeta as not restored by Get
+	m.TypeMeta = typeMeta
+}


### PR DESCRIPTION
This PR adds a termination handler for spot instances. It is based on the termination handler that Joel wrote for AWS and has similar logic.

In order to get the termination notice, we should poll `scheduledevents` endpoint, unmarshal json and check for `Preempt` event 


https://github.com/openshift/cluster-api-provider-aws/pull/308
https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/spot-instances.md