### PR TITLE
BUG 1836141: Assert VM exists if VM state is Creating

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -372,11 +372,17 @@ func (s *Reconciler) Exists(ctx context.Context) (bool, error) {
 		}
 	}
 
+	// VM States come from https://docs.microsoft.com/en-us/azure/virtual-machines/windows/states-lifecycle#provisioning-states
 	switch v1beta1.VMState(*vm.ProvisioningState) {
 	case v1beta1.VMStateSucceeded:
+		// VM was created or updated successfully
 		klog.Infof("Machine %v is running", to.String(vm.VMID))
 	case v1beta1.VMStateUpdating:
+		// Some update is being applied
 		klog.Infof("Machine %v is updating", to.String(vm.VMID))
+	case v1beta1.VMStateCreating:
+		// Creation request was accepted, VM is being created
+		klog.Infof("Machine %v is creating", to.String(vm.VMID))
 	default:
 		klog.Infof("Not found vm for machine %s", s.scope.Machine.GetName())
 		return false, nil

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -34,6 +34,14 @@ func TestExists(t *testing.T) {
 			vmService: &FakeVMService{
 				Name:              "machine-test",
 				ID:                "machine-test-ID",
+				ProvisioningState: string(v1beta1.VMStateCreating),
+			},
+			expected: true,
+		},
+		{
+			vmService: &FakeVMService{
+				Name:              "machine-test",
+				ID:                "machine-test-ID",
 				ProvisioningState: "",
 			},
 			expected: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when a VM is being created in Azure, we first check whether the VM exists and then attempt to create it if not.

On the first attempt to create, we always get an asynchronous time out:
```
E0709 16:44:25.752572       1 actuator.go:78] Machine error: failed to reconcile machine "jspeed-test-8cnpg-worker-centralus3-g6htz"s: failed to create vm jspeed-test-8cnpg-worker-centralus3-g6htz: failed to create or get machine: compute.VirtualMachinesCreateOrUpdateFuture: asynchronous operation has not completed
```

This will cause the Machine to be requeued. Currently, because Exists does not determine the machine to exist, we attempt to create again and get the following error:

```
E0709 16:44:26.642473       1 actuator.go:78] Machine error: failed to reconcile machine "jspeed-test-8cnpg-worker-centralus3-g6htz"s: failed to create vm jspeed-test-8cnpg-worker-centralus3-g6htz: vm jspeed-test-8cnpg-worker-centralus3-g6htz is still in provisioning state Creating, reconcile
```

The VM exists immediately after the first call to create the VM, but we are attempting to recreate it becuase `Exists` claims that it does not exist. This can lead to issues if there is a transient error after the first `Create` but before the VM becomes `Running`. We could see an error, determine the creation failed and move the Machine to the `Failed` phase.

If this happens, the VM will still start, but because the Machine is Failed, we do not track it, we do not remove it if the Machine is deleted. Therefore we can leak VMs.

This PR fixes `Exists` such that if the VM exists on the API, but is in the `Creating` phase, it is considered to exist. Now we do not attempt to create the VM more than once and, if the first VM creation is successful (even with the async error), the Machine is considered to exist, so we will not fail a Machine while the VM is in the `Creating` phase.
