### PR TITLE
Ensure empty max price does not cause error when creating a spot VM

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -657,7 +657,7 @@ func getSpotVMOptions(spotVMOptions *v1beta1.SpotVMOptions) (compute.VirtualMach
 		return compute.VirtualMachinePriorityTypes(""), compute.VirtualMachineEvictionPolicyTypes(""), nil, nil
 	}
 	var billingProfile *compute.BillingProfile
-	if spotVMOptions.MaxPrice != nil {
+	if spotVMOptions.MaxPrice != nil && *spotVMOptions.MaxPrice != "" {
 		maxPrice, err := strconv.ParseFloat(*spotVMOptions.MaxPrice, 64)
 		if err != nil {
 			return compute.VirtualMachinePriorityTypes(""), compute.VirtualMachineEvictionPolicyTypes(""), nil, err

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -58,6 +58,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	maxPriceEmpty := ""
 
 	testCases := []struct {
 		name           string
@@ -84,6 +85,28 @@ func TestGetSpotVMOptions(t *testing.T) {
 			evictionPolicy: "",
 			billingProfile: nil,
 		},
+		{
+			name: "not return an error if the max price is the empty string",
+			spotVMOptions: &v1beta1.SpotVMOptions{
+				MaxPrice: &maxPriceEmpty,
+			},
+			priority:       compute.Spot,
+			evictionPolicy: compute.Deallocate,
+			billingProfile: &compute.BillingProfile{
+				MaxPrice: nil,
+			},
+		},
+		{
+			name: "not return an error if the max price is nil",
+			spotVMOptions: &v1beta1.SpotVMOptions{
+				MaxPrice: nil,
+			},
+			priority:       compute.Spot,
+			evictionPolicy: compute.Deallocate,
+			billingProfile: &compute.BillingProfile{
+				MaxPrice: nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -103,8 +126,12 @@ func TestGetSpotVMOptions(t *testing.T) {
 
 			// only check billing profile when spotVMOptions object is not nil
 			if tc.spotVMOptions != nil {
-				if *billingProfile.MaxPrice != *tc.billingProfile.MaxPrice {
-					t.Fatalf("Expected billing profile max price %d, got: %d", billingProfile, tc.billingProfile)
+				if tc.billingProfile.MaxPrice != nil {
+					if billingProfile == nil {
+						t.Fatal("Expected billing profile to not be nil")
+					} else if *billingProfile.MaxPrice != *tc.billingProfile.MaxPrice {
+						t.Fatalf("Expected billing profile max price %d, got: %d", billingProfile, tc.billingProfile)
+					}
 				}
 			} else {
 				if billingProfile != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
While attempting to create a spot VM, my providerspec `spotVMOptions: {}` got expanded to 
```
spotVMOptions:
  maxPrice: ""
```
Not sure why this happened, it shouldn't have, need to work that out still, but it did lead to this error from the machine creation:
```
message: 'failed to create vm jspeed-test-n7vrfcqlpr-k4dcg: failed to get Spot
        VM options strconv.ParseFloat: parsing "": invalid syntax'
```

This PR ensures that we ignore empty `MaxPrice` values and do not return an error in the case that the `MaxPrice` is for some reason, the empty string.