### PR TITLE
Disable keep alives on termination handler connection

### DIFF
--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -95,6 +95,12 @@ func (h *handler) Run(stop <-chan struct{}) error {
 }
 
 func (h *handler) run(ctx context.Context) error {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("expected http.DefaultTransport to be *http.Transport, got: %T", http.DefaultTransport)
+	}
+	defaultTransport.DisableKeepAlives = true
+
 	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
 		req, err := http.NewRequest("GET", h.pollURL.String(), nil)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable keep alives on the connection to the Azure metadata service from the termination handler

When testing against the E2E suite (as part of testing https://github.com/openshift/cluster-api-actuator-pkg/pull/170), I noticed that once the metadata mock was deployed, nothing was happening. I could reach the mock service from the termination pod, but it was not connecting to it. Restarting the container allowed it to reach the metadata mock.

I believe that the connection to the Azure metadata service was being held and as such not re-establishing the connection, and so not going through the new iptables rules.

Having tested this, it resolves the issue. Ideally we wouldn't have to have this here since it's not helpful in the real world. If we can somehow reset the connection another way that would be preferable and I am open to ideas.