### PR TITLE
Bug 1860229: Fail machine if create request doesn't succeed

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-12-01/network"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
@@ -607,6 +608,11 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName string) e
 				Namespace: s.scope.Machine.Namespace,
 				Reason:    err.Error(),
 			})
+
+			var detailedError autorest.DetailedError
+			if errors.As(err, &detailedError) && detailedError.Message == "Failure sending request" {
+				return machinecontroller.InvalidMachineConfiguration("failure sending request for machine %s", s.scope.Machine.Name)
+			}
 			return fmt.Errorf("failed to create or get machine: %w", err)
 		}
 	} else if err != nil {


### PR DESCRIPTION
Fail machine if create request doesn't succeed.
For spot instances when the max price is lower than the current spot price, we should fail the machine. Currently, we are constantly trying to provision it. Azure error types are not great, so I think this is the cleanest way to fail machines.
This approach will also fail the machines in other cases like reaching quota limits.