### PR TITLE
BUG 1858400: [Performance] Lease refresh period for machine-api-controllers is too high, causes heavy writes to etcd at idle

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,6 +38,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 20 * time.Second
+)
+
 func main() {
 	watchNamespace := flag.String(
 		"namespace",
@@ -71,7 +78,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -88,6 +95,9 @@ func main() {
 		LeaderElectionID:        "cluster-api-provider-azure-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
 		MetricsBindAddress:      *metricsAddress,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	if *watchNamespace != "" {


### PR DESCRIPTION
Reduce default lease retry rate on `30s` which will prevent from heavy writes into etcd at idle, and constrain renew deadline on `90s`.

Inspired by https://github.com/openshift/cloud-credential-operator/pull/231
Depends on https://github.com/openshift/machine-api-operator/pull/675