### PR TITLE
Bug 1872080: Add Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,24 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 as builder
+WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-azure
+COPY . .
+# VERSION env gets set in the openshift/release image and refers to the golang version, which interferes with our own
+RUN unset VERSION \
+  && GOPROXY=off NO_DOCKER=1 make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-azure/bin/machine-controller-manager /
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-azure/bin/termination-handler /


### PR DESCRIPTION
This PR is a copy of the autogenerated PR by the
[ocp-build-data-enforcer](https://github.com/openshift/ci-tools/tree/master/cmd/ocp-build-data-enforcer).
It updates the baseimages in the Dockerfile used for promotion in order
to ensure it matches the configuration in the [ocp-build-data
repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

If you believe the content of this PR is incorrect, please contact the
dptp team in #forum-testplatform