### PR TITLE
Bug 1881154: Add AdditionalUnattendContent on Windows machines

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -617,7 +617,7 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName string) e
 
 			var detailedError autorest.DetailedError
 			if errors.As(err, &detailedError) && detailedError.Message == "Failure sending request" {
-				return machinecontroller.InvalidMachineConfiguration("failure sending request for machine %s", s.scope.Machine.Name)
+				return machinecontroller.InvalidMachineConfiguration("failure sending request for machine %s: %v", s.scope.Machine.Name, err)
 			}
 			return fmt.Errorf("failed to create or get machine: %w", err)
 		}


### PR DESCRIPTION
This commit adds functionality for automatically running
C:\AzureData\CustomData.bin on first boot.
This custom data file is provided via the user data secret,
and contains init scripts.

The Windows Machine Config Operator relies on the user data script being
started automatically on the Windows VM to set up SSH access.

On AWS, it is invoked automatically after provisioning.
This commit is intended to align Azure with that behavior.

I've tested this manually and verified it works.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```