### PR TITLE
[OCPCLOUD-809] Add verify-diff check in generate task and enable in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,11 @@ goimports: ## Go fmt your code
 	hack/goimports.sh .
 
 .PHONY: generate
-generate:
+generate: gogen goimports
+	./hack/verify-diff.sh
+
+gogen:
 	$(DOCKER_CMD) go generate ./pkg/... ./cmd/...
-	hack/goimports.sh .
 
 .PHONY: vet
 vet:

--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,0 +1,9 @@
+FILE_DIFF=$(git ls-files -o --exclude-standard)
+
+if [ "$FILE_DIFF" != "" ]; then
+  echo "Found untracked files:"
+  echo $FILE_DIFF
+  exit 1
+fi
+
+git diff --exit-code


### PR DESCRIPTION
**What this PR does / why we need it**:

Allowing automatic `make generate` checks in CI. It allows to keep track of API changes, client generated code updates on each PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This PR is dependent on https://github.com/openshift/release/pull/13400 to enable the functionality in CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```