### PR TITLE
[OCPCLOUD-1043] Bug 1902157: Update termination handler to use node conditions

### DIFF
--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -3,7 +3,6 @@ package termination
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,8 +11,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -23,18 +22,19 @@ import (
 const (
 	// azureTerminationEndpointURL see the following link for more details about the endpoint
 	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#endpoint-discovery
-	azureTerminationEndpointURL = "http://169.254.169.254/metadata/scheduledevents?api-version=2019-08-01"
+	azureTerminationEndpointURL                          = "http://169.254.169.254/metadata/scheduledevents?api-version=2019-08-01"
+	terminatingConditionType    corev1.NodeConditionType = "Terminating"
+	terminationRequestedReason                           = "TerminationRequested"
 )
 
 // Handler represents a handler that will run to check the termination
-// notice endpoint and delete Machine's if the instance termination notice is fulfilled.
+// notice endpoint and mark node for deletion if the instance termination notice is fulfilled.
 type Handler interface {
 	Run(stop <-chan struct{}) error
 }
 
 // NewHandler constructs a new Handler
 func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, namespace, nodeName string) (Handler, error) {
-	machinev1.AddToScheme(scheme.Scheme)
 	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err)
@@ -95,6 +95,9 @@ func (h *handler) Run(stop <-chan struct{}) error {
 }
 
 func (h *handler) run(ctx context.Context) error {
+	logger := h.log.WithValues("node", h.nodeName)
+	logger.V(1).Info("Monitoring node termination")
+
 	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
 		req, err := http.NewRequest("GET", h.pollURL.String(), nil)
 		if err != nil {
@@ -127,58 +130,85 @@ func (h *handler) run(ctx context.Context) error {
 		}
 
 		// Instance not terminated yet
-		h.log.V(2).Info("Instance not marked for termination")
+		logger.V(2).Info("Instance not marked for termination")
 		return false, nil
 	}, ctx.Done()); err != nil {
 		return fmt.Errorf("error polling termination endpoint: %w", err)
 	}
 
-	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
-		h.log.V(1).Info("Getting node for machine")
-		machine, err := h.getMachineForNode(ctx)
-		if err != nil {
-			if errors.Is(err, notFoundMachineForNode{}) {
-				h.log.Error(err, "Machine not found for node")
-				return true, nil
-			}
-			h.log.Error(err, "error fetching machine for node:", h.nodeName)
-			return false, nil
-		}
-
-		// Will only get here if the termination endpoint returned FALSE
-		h.log.Info("Instance marked for termination, deleting Machine")
-		if err := h.client.Delete(ctx, machine); err != nil {
-			if apierrors.IsNotFound(err) {
-				h.log.Error(err, "Machine not found when deleting")
-				return true, nil
-			}
-			h.log.Error(err, "Error deleting machine")
-			return false, nil
-		}
-
-		return true, nil
-	}, ctx.Done()); err != nil {
-		return fmt.Errorf("error getting and deleting machine: %w", err)
+	// Will only get here if the termination endpoint returned FALSE
+	logger.V(1).Info("Instance marked for termination, marking Node for deletion")
+	if err := h.markNodeForDeletion(ctx); err != nil {
+		return fmt.Errorf("error marking node: %v", err)
 	}
 
 	return nil
 }
 
-// getMachineForNodeName finds the Machine associated with the Node name given
-func (h *handler) getMachineForNode(ctx context.Context) (*machinev1.Machine, error) {
-	machineList := &machinev1.MachineList{}
-	err := h.client.List(ctx, machineList, client.InNamespace(h.namespace))
-	if err != nil {
-		return nil, fmt.Errorf("error listing machines: %w", err)
+func (h *handler) markNodeForDeletion(ctx context.Context) error {
+	node := &corev1.Node{}
+	if err := h.client.Get(ctx, client.ObjectKey{Name: h.nodeName}, node); err != nil {
+		return fmt.Errorf("error fetching node: %v", err)
 	}
 
-	for _, machine := range machineList.Items {
-		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == h.nodeName {
-			return &machine, nil
+	addNodeTerminationCondition(node)
+	if err := h.client.Status().Update(ctx, node); err != nil {
+		return fmt.Errorf("error updating node status")
+	}
+	return nil
+}
+
+// nodeHasTerminationCondition checks whether the node already
+// has a condition with the terminatingConditionType type
+func nodeHasTerminationCondition(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == terminatingConditionType {
+			return true
 		}
 	}
+	return false
+}
 
-	return nil, notFoundMachineForNode{}
+// addNodeTerminationCondition will add a condition with a
+// terminatingConditionType type to the node
+func addNodeTerminationCondition(node *corev1.Node) {
+	now := metav1.Now()
+	terminatingCondition := corev1.NodeCondition{
+		Type:               terminatingConditionType,
+		Status:             corev1.ConditionTrue,
+		LastHeartbeatTime:  now,
+		LastTransitionTime: now,
+		Reason:             terminationRequestedReason,
+		Message:            "The cloud provider has marked this instance for termination",
+	}
+
+	if !nodeHasTerminationCondition(node) {
+		// No need to merge, just add the new condition to the end
+		node.Status.Conditions = append(node.Status.Conditions, terminatingCondition)
+		return
+	}
+
+	// The node already has a terminating condition,
+	// so make sure it has the correct status
+	conditions := []corev1.NodeCondition{}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type != terminatingConditionType {
+			conditions = append(conditions, condition)
+			continue
+		}
+
+		// Condition type is terminating
+		if condition.Status == corev1.ConditionTrue {
+			// Condition already marked true, do not update
+			conditions = append(conditions, condition)
+			continue
+		}
+
+		// The existing terminating condition had the wrong status
+		conditions = append(conditions, terminatingCondition)
+	}
+
+	node.Status.Conditions = conditions
 }
 
 const preemptEventType = "Preempt"

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -24,11 +24,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,9 +38,32 @@ var _ = Describe("Handler Suite", func() {
 	var terminationServer *httptest.Server
 	var httpHandler http.Handler
 	var nodeName string
+	var testNode *corev1.Node
+
 	var stop chan struct{}
 	var errs chan error
 	var h *handler
+
+	nodeMarkedForDeletion := func(nodeName string) func() (bool, error) {
+		key := client.ObjectKey{Name: nodeName}
+		return func() (bool, error) {
+			n := &corev1.Node{}
+			err := k8sClient.Get(ctx, key, n)
+			if err != nil {
+				return false, err
+			}
+			for _, condition := range n.Status.Conditions {
+				if condition.Type == terminatingConditionType {
+					if condition.Status == corev1.ConditionTrue {
+						return true, nil
+					}
+					// Found the condition with the right type, but wrong status
+					return false, nil
+				}
+			}
+			return false, nil
+		}
+	}
 
 	BeforeEach(func() {
 		// Reset test vars
@@ -53,6 +73,9 @@ var _ = Describe("Handler Suite", func() {
 		httpHandler = newMockHTTPHandler(emptyEvents)
 		stop = nil
 		errs = nil
+
+		testNode = newTestNode(nodeName)
+		createNode(testNode)
 
 		// use NewHandler() instead of manual construction in order to test NewHandler() logic
 		// like checking that machine api is added to scheme
@@ -74,6 +97,8 @@ var _ = Describe("Handler Suite", func() {
 			Expect(err).ToNot(HaveOccurred())
 			h.pollURL = pollURL
 		}
+
+		stop, errs = StartTestHandler(h)
 	})
 
 	AfterEach(func() {
@@ -82,15 +107,42 @@ var _ = Describe("Handler Suite", func() {
 		}
 		terminationServer.Close()
 
-		Expect(deleteAllMachines(k8sClient)).To(Succeed())
+		Expect(deleteAllNodes(k8sClient)).To(Succeed())
 	})
 
-	Context("when running the handler", func() {
+	Context("when the handler is stopped", func() {
 		JustBeforeEach(func() {
-			stop, errs = StartTestHandler(h)
+			close(stop)
 		})
 
-		Context("when the handler is stopped", func() {
+		It("should not return an error", func() {
+			Eventually(errs).Should(Receive(BeNil()))
+		})
+	})
+
+	Context("when polling the termination endpoint", func() {
+		var counter int32
+
+		BeforeEach(func() {
+			// Ensure the polling logic is excercised in tests
+			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+				if atomic.LoadInt32(&counter) == 4 {
+					rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[{"EventType":"Preempt", "ResourceType": "VirtualMachine"}]}`))
+				} else {
+					atomic.AddInt32(&counter, 1)
+					rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
+				}
+			})
+		})
+
+		JustBeforeEach(func() {
+			// Ensure the polling logic is excercised in tests
+			for atomic.LoadInt32(&counter) < 4 {
+				continue
+			}
+		})
+
+		Context("and the handler is stopped", func() {
 			JustBeforeEach(func() {
 				close(stop)
 			})
@@ -98,157 +150,137 @@ var _ = Describe("Handler Suite", func() {
 			It("should not return an error", func() {
 				Eventually(errs).Should(Receive(BeNil()))
 			})
-		})
 
-		Context("when no machine exists for the node", func() {
-			It("should not receive an error upon starting", func() {
-				Consistently(errs).ShouldNot(Receive())
+			It("should not mark the node for deletion", func() {
+				Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 			})
 		})
 
-		Context("when a machine exists for the node", func() {
-			var counter int32
-			var testMachine *machinev1.Machine
+		Context("and the instance termination notice is fulfilled", func() {
+			It("should mark the node for deletion", func() {
+				Eventually(nodeMarkedForDeletion(testNode.Name)).Should(BeTrue())
+			})
+		})
 
+		Context("and the instance termination notice is not fulfilled", func() {
 			BeforeEach(func() {
-				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
-				createMachine(testMachine)
-
-				// Ensure the polling logic is excercised in tests
-				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
-					if atomic.LoadInt32(&counter) == 4 {
-						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[{"EventType":"Preempt", "ResourceType": "VirtualMachine"}]}`))
-					} else {
-						atomic.AddInt32(&counter, 1)
-						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
-					}
-				})
+				httpHandler = newMockHTTPHandler(emptyEvents)
 			})
 
-			JustBeforeEach(func() {
-				// Ensure the polling logic is excercised in tests
-				for atomic.LoadInt32(&counter) < 4 {
-					continue
-				}
+			It("should not mark the node for deletion", func() {
+				Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
+			})
+		})
+
+		Context("and the poll URL cannot be reached", func() {
+			BeforeEach(func() {
+				h.pollURL = &url.URL{Opaque: "abc#1://localhost"}
 			})
 
-			Context("and the handler is stopped", func() {
-				JustBeforeEach(func() {
-					close(stop)
-				})
-
-				It("should not return an error", func() {
-					Eventually(errs).Should(Receive(BeNil()))
-				})
-
-				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
-				})
+			It("should return an error", func() {
+				Eventually(errs).Should(Receive(MatchError(ContainSubstring("error polling termination endpoint: could not get URL \"abc#1://localhost\":"))))
 			})
 
-			Context("and the instance termination notice is fulfilled", func() {
-				It("should delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Eventually(func() error {
-						m := &machinev1.Machine{}
-						err := k8sClient.Get(ctx, key, m)
-						if err != nil && errors.IsNotFound(err) {
-							return nil
-						} else if err != nil {
-							return err
-						}
-						return fmt.Errorf("machine not yet deleted")
-					}).Should(Succeed())
-				})
-			})
-
-			Context("and the instance termination notice is not fulfilled", func() {
-				BeforeEach(func() {
-					httpHandler = newMockHTTPHandler(emptyEvents)
-				})
-
-				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
-				})
-			})
-
-			Context("and the poll URL cannot be reached", func() {
-				BeforeEach(func() {
-					h.pollURL = &url.URL{Opaque: "abc#1://localhost"}
-				})
-
-				It("should return an error", func() {
-					Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
-				})
-
-				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
-				})
+			It("should not delete the machine", func() {
+				Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 			})
 		})
 	})
 
-	Context("getMachineForNode", func() {
-		var machine *machinev1.Machine
-		var err error
-
+	Context("addNodeTerminationCondition", func() {
 		JustBeforeEach(func() {
-			machine, err = h.getMachineForNode(ctx)
+			addNodeTerminationCondition(testNode)
 		})
 
-		Context("with a broken client", func() {
+		Context("with no existing conditions", func() {
 			BeforeEach(func() {
-				brokenClient, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
-				Expect(err).ToNot(HaveOccurred())
-				h.client = brokenClient
+				Expect(testNode.Status.Conditions).To(HaveLen(0))
 			})
 
-			It("should return an error", func() {
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(HavePrefix("error listing machines: no kind is registered for the type v1beta1.MachineList in scheme"))
-			})
-
-			It("should not return a machine", func() {
-				Expect(machine).To(BeNil())
+			It("should add the condition to the node", func() {
+				Expect(testNode.Status.Conditions).To(HaveLen(1))
+				condition := testNode.Status.Conditions[0]
+				Expect(condition.Type).To(Equal(terminatingConditionType))
+				Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+				Expect(condition.Reason).To(Equal(terminationRequestedReason))
 			})
 		})
 
-		Context("with no machine for the node name", func() {
-			It("should return an error", func() {
-				Expect(err).To(MatchError(notFoundMachineForNode{}))
-			})
-
-			It("should not return a machine", func() {
-				Expect(machine).To(BeNil())
-			})
-		})
-
-		Context("with a machine matching the node name", func() {
-			var testMachine *machinev1.Machine
+		Context("with the terminating condition with the correct status", func() {
+			var updated *metav1.Time
 
 			BeforeEach(func() {
-				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
-				createMachine(testMachine)
+				now := metav1.Now()
+				updated = &now
+				testNode.Status.Conditions = []corev1.NodeCondition{
+					{
+						Type:               terminatingConditionType,
+						Status:             corev1.ConditionTrue,
+						Reason:             terminationRequestedReason,
+						LastTransitionTime: now,
+						LastHeartbeatTime:  now,
+					},
+				}
 			})
 
-			It("should not return an error", func() {
-				Expect(err).ToNot(HaveOccurred())
+			It("should not update the condition on the node", func() {
+				Expect(testNode.Status.Conditions).To(HaveLen(1))
+				condition := testNode.Status.Conditions[0]
+				Expect(condition.Type).To(Equal(terminatingConditionType))
+				Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+				Expect(condition.Reason).To(Equal(terminationRequestedReason))
+				Expect(condition.LastTransitionTime).To(Equal(*updated))
+				Expect(condition.LastHeartbeatTime).To(Equal(*updated))
+			})
+		})
+
+		Context("with the terminating condition with the incorrect status", func() {
+			var updated *metav1.Time
+
+			BeforeEach(func() {
+				now := metav1.Now()
+				updated = &now
+				testNode.Status.Conditions = []corev1.NodeCondition{
+					{
+						Type:               terminatingConditionType,
+						Status:             corev1.ConditionFalse,
+						Reason:             terminationRequestedReason,
+						LastTransitionTime: now,
+						LastHeartbeatTime:  now,
+					},
+				}
 			})
 
-			It("should return a machine", func() {
-				Expect(machine).To(Equal(testMachine))
+			It("should update the condition on the node", func() {
+				Expect(testNode.Status.Conditions).To(HaveLen(1))
+				condition := testNode.Status.Conditions[0]
+				Expect(condition.Type).To(Equal(terminatingConditionType))
+				Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+				Expect(condition.Reason).To(Equal(terminationRequestedReason))
+				Expect(condition.LastTransitionTime).ToNot(Equal(*updated))
+				Expect(condition.LastHeartbeatTime).ToNot(Equal(*updated))
+			})
+		})
+
+		Context("with existing conditions", func() {
+			var existingCondition *corev1.NodeCondition
+
+			BeforeEach(func() {
+				now := metav1.Now()
+				existingCondition = &corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					Reason:             "Unknown",
+					LastTransitionTime: now,
+					LastHeartbeatTime:  now,
+				}
+
+				testNode.Status.Conditions = []corev1.NodeCondition{*existingCondition}
+			})
+
+			It("should not modify the existing conditions", func() {
+				Expect(testNode.Status.Conditions).To(HaveLen(2))
+				Expect(testNode.Status.Conditions).To(ContainElement(Equal(*existingCondition)))
 			})
 		})
 	})
@@ -313,17 +345,17 @@ func isClosed(ch <-chan struct{}) bool {
 	return false
 }
 
-func deleteAllMachines(c client.Client) error {
-	machineList := &machinev1.MachineList{}
-	err := c.List(ctx, machineList)
+func deleteAllNodes(c client.Client) error {
+	nodeList := &corev1.NodeList{}
+	err := c.List(ctx, nodeList)
 	if err != nil {
 		return fmt.Errorf("error listing machines: %v", err)
 	}
 
-	// Delete all machines found
-	for _, machine := range machineList.Items {
-		m := machine
-		err := c.Delete(ctx, &m)
+	// Delete all nodes found
+	for _, node := range nodeList.Items {
+		n := node
+		err := c.Delete(ctx, &n)
 		if err != nil {
 			return err
 		}
@@ -331,34 +363,28 @@ func deleteAllMachines(c client.Client) error {
 	return nil
 }
 
-func newTestMachine(name, namespace, nodeName string) *machinev1.Machine {
-	return &machinev1.Machine{
+func newTestNode(name string) *corev1.Node {
+	return &corev1.Node{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Machine",
-			APIVersion: machinev1.SchemeGroupVersion.String(),
+			Kind:       "Node",
+			APIVersion: "",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Status: machinev1.MachineStatus{
-			NodeRef: &corev1.ObjectReference{
-				Name: nodeName,
-			},
+			Name: name,
 		},
 	}
 }
 
-func createMachine(m *machinev1.Machine) {
-	typeMeta := m.TypeMeta
-	status := m.Status
-	Expect(k8sClient.Create(ctx, m)).To(Succeed())
-	m.Status = status
-	Expect(k8sClient.Status().Update(ctx, m)).To(Succeed())
+func createNode(n *corev1.Node) {
+	typeMeta := n.TypeMeta
+	status := n.Status
+	Expect(k8sClient.Create(ctx, n)).To(Succeed())
+	n.Status = status
+	Expect(k8sClient.Status().Update(ctx, n)).To(Succeed())
 
 	// Fetch object to sync back to latest changes
-	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
-	Expect(k8sClient.Get(ctx, key, m)).To(Succeed())
+	key := client.ObjectKey{Namespace: n.Namespace, Name: n.Name}
+	Expect(k8sClient.Get(ctx, key, n)).To(Succeed())
 	// Restore TypeMeta as not restored by Get
-	m.TypeMeta = typeMeta
+	n.TypeMeta = typeMeta
 }


### PR DESCRIPTION
Switch from deleting the Machine to marking the Node with a Terminating condition.
This will integrate with an MHC to ensure that the Machine is deleted.
This should be possible using the Node's credentials and as such, the termination handler will not need its own credentials and extra permissions.

Requires openshift/machine-api-operator#627 before it will work

openshift/cluster-api-provider-aws#332