### PR TITLE
Updating ose-azure-machine-controllers builder & base images to be consistent with ART 

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-azure
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interferes with our own
 RUN unset VERSION \
   && GOPROXY=off NO_DOCKER=1 make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-azure/bin/machine-controller-manager /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-azure/bin/termination-handler /


### PR DESCRIPTION
This replaces #194 with the correct git-history naming

Updating ose-azure-machine-controllers builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/3d1d49f1c8fabf829e5a88e575485c0091329ac2/images/ose-azure-machine-controllers.yml

If you have any questions about this pull request, please reach out to @art-team in the #aos-art coreos slack channel.