### PR TITLE
[OCPCLOUD-1108] Fix spot instances price type

### DIFF
--- a/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1beta1/azuremachineproviderconfig_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -100,7 +101,7 @@ type AzureMachineProviderSpec struct {
 // SpotVMOptions defines the options relevant to running the Machine on Spot VMs
 type SpotVMOptions struct {
 	// MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
-	MaxPrice *string `json:"maxPrice,omitempty"`
+	MaxPrice *resource.Quantity `json:"maxPrice,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/azureprovider/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/azureprovider/v1beta1/zz_generated.deepcopy.go
@@ -493,8 +493,8 @@ func (in *SpotVMOptions) DeepCopyInto(out *SpotVMOptions) {
 	*out = *in
 	if in.MaxPrice != nil {
 		in, out := &in.MaxPrice, &out.MaxPrice
-		*out = new(string)
-		**out = **in
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -680,8 +680,8 @@ func getSpotVMOptions(spotVMOptions *v1beta1.SpotVMOptions) (compute.VirtualMach
 		return compute.VirtualMachinePriorityTypes(""), compute.VirtualMachineEvictionPolicyTypes(""), nil, nil
 	}
 	var billingProfile *compute.BillingProfile
-	if spotVMOptions.MaxPrice != nil && *spotVMOptions.MaxPrice != "" {
-		maxPrice, err := strconv.ParseFloat(*spotVMOptions.MaxPrice, 64)
+	if spotVMOptions.MaxPrice != nil && spotVMOptions.MaxPrice.AsDec().String() != "" {
+		maxPrice, err := strconv.ParseFloat(spotVMOptions.MaxPrice.AsDec().String(), 64)
 		if err != nil {
 			return compute.VirtualMachinePriorityTypes(""), compute.VirtualMachineEvictionPolicyTypes(""), nil, err
 		}

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
@@ -69,12 +70,11 @@ func TestExists(t *testing.T) {
 }
 
 func TestGetSpotVMOptions(t *testing.T) {
-	maxPriceString := "100"
-	maxPriceFloat, err := strconv.ParseFloat(maxPriceString, 64)
+	maxPrice := resource.MustParse("0.001")
+	maxPriceFloat, err := strconv.ParseFloat(maxPrice.AsDec().String(), 64)
 	if err != nil {
 		t.Fatal(err)
 	}
-	maxPriceEmpty := ""
 
 	testCases := []struct {
 		name           string
@@ -86,7 +86,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 		{
 			name: "get spot vm option succefully",
 			spotVMOptions: &v1beta1.SpotVMOptions{
-				MaxPrice: &maxPriceString,
+				MaxPrice: &maxPrice,
 			},
 			priority:       compute.Spot,
 			evictionPolicy: compute.Deallocate,
@@ -102,10 +102,8 @@ func TestGetSpotVMOptions(t *testing.T) {
 			billingProfile: nil,
 		},
 		{
-			name: "not return an error if the max price is the empty string",
-			spotVMOptions: &v1beta1.SpotVMOptions{
-				MaxPrice: &maxPriceEmpty,
-			},
+			name:           "not return an error with empty spot vm options",
+			spotVMOptions:  &v1beta1.SpotVMOptions{},
 			priority:       compute.Spot,
 			evictionPolicy: compute.Deallocate,
 			billingProfile: &compute.BillingProfile{
@@ -165,7 +163,7 @@ func TestSetMachineCloudProviderSpecifics(t *testing.T) {
 	testZone := "testZone"
 	testZones := []string{testZone}
 
-	maxPrice := "1"
+	maxPrice := resource.MustParse("1")
 	r := Reconciler{
 		scope: &actuators.MachineScope{
 			Machine: &machinev1.Machine{


### PR DESCRIPTION
Ticket description: `A bug was identified upstream in that go clients were hitting validation errors when trying to serialize the field. The solution they found upstream was to move the field to a resource.Quantity.`

Upstream PR: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1157