### PR TITLE
Bug 1959479: UPSTREAM: <carry>: openshift: Fix dual stack support for machines with Load Balancers associated

### DIFF
--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/services/applicationsecuritygroups"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/services/internalloadbalancers"
@@ -70,9 +70,6 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		return errors.New("invalid network interface specification")
 	}
 
-	nicProp := network.InterfacePropertiesFormat{}
-	nicConfig := &network.InterfaceIPConfigurationPropertiesFormat{}
-
 	subnetInterface, err := subnets.NewService(s.Scope).Get(ctx, &subnets.Spec{Name: nicSpec.SubnetName, VnetName: nicSpec.VnetName})
 	if err != nil {
 		return err
@@ -82,14 +79,36 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	if !ok {
 		return errors.New("subnet get returned invalid network interface")
 	}
+	nicHasIPv6 := subnetHasIPv6(subnet)
+
+	nicProp := network.InterfacePropertiesFormat{}
+	nicConfig := &network.InterfaceIPConfigurationPropertiesFormat{}
+	nicConfigV6 := &network.InterfaceIPConfigurationPropertiesFormat{}
 
 	nicConfig.Subnet = &network.Subnet{ID: subnet.ID}
 	nicConfig.PrivateIPAllocationMethod = network.Dynamic
-	if nicSpec.StaticIPAddress != "" {
-		nicConfig.PrivateIPAllocationMethod = network.Static
-		nicConfig.PrivateIPAddress = to.StringPtr(nicSpec.StaticIPAddress)
+	nicConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{}
+	if nicHasIPv6 {
+		klog.V(2).Infof("Found IPv6 address space. Adding IPv6 configuration to nic: %s", nicSpec.Name)
+		nicConfigV6.Subnet = &network.Subnet{ID: subnet.ID}
+		nicConfigV6.PrivateIPAllocationMethod = network.Dynamic
+		nicConfigV6.PrivateIPAddressVersion = network.IPv6
+		nicConfigV6.LoadBalancerInboundNatRules = &[]network.InboundNatRule{}
+		nicConfigV6.Primary = to.BoolPtr(false)
 	}
 
+	// IP address allocation
+	if nicSpec.StaticIPAddress != "" {
+		if utilnet.IsIPv6String(nicSpec.StaticIPAddress) {
+			nicConfigV6.PrivateIPAllocationMethod = network.Static
+			nicConfigV6.PrivateIPAddress = to.StringPtr(nicSpec.StaticIPAddress)
+		} else {
+			nicConfig.PrivateIPAllocationMethod = network.Static
+			nicConfig.PrivateIPAddress = to.StringPtr(nicSpec.StaticIPAddress)
+		}
+	}
+
+	// associated public IPs
 	if nicSpec.PublicIP != "" {
 		publicIPInterface, publicIPErr := publicips.NewService(s.Scope).Get(ctx, &publicips.Spec{Name: nicSpec.PublicIP})
 		if publicIPErr != nil {
@@ -100,10 +119,17 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		if !ok {
 			return errors.New("public ip get returned invalid network interface")
 		}
-		nicConfig.PublicIPAddress = &ip
+
+		if ip.PublicIPAddressPropertiesFormat.PublicIPAddressVersion == network.IPv6 {
+			nicConfigV6.PublicIPAddress = &ip
+		} else {
+			nicConfig.PublicIPAddress = &ip
+		}
 	}
 
+	// associated Load Balancers
 	backendAddressPools := []network.BackendAddressPool{}
+	backendAddressPoolsV6 := []network.BackendAddressPool{}
 	if nicSpec.PublicLoadBalancerName != "" {
 		lbInterface, lberr := publicloadbalancers.NewService(s.Scope).Get(ctx, &publicloadbalancers.Spec{Name: nicSpec.PublicLoadBalancerName})
 		if lberr != nil {
@@ -115,17 +141,42 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 			return errors.New("public load balancer get returned invalid network interface")
 		}
 
-		backendAddressPools = append(backendAddressPools,
-			network.BackendAddressPool{
-				ID: (*lb.BackendAddressPools)[0].ID,
-			})
-		if nicSpec.NatRule != nil {
-			nicConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{
-				{
-					ID: (*lb.InboundNatRules)[*nicSpec.NatRule].ID,
-				},
+		loadBalancerInboundNatRules := []network.InboundNatRule{}
+		loadBalancerInboundNatRulesV6 := []network.InboundNatRule{}
+		// loadbalancers can have multiple frontends and backends with different IP families
+		for i, ipConfig := range *lb.FrontendIPConfigurations {
+			// iterate only for the frontends that have backends configured
+			if i >= len(*lb.BackendAddressPools) {
+				break
+			}
+			if ipConfig.PrivateIPAddressVersion == network.IPv6 {
+				backendAddressPoolsV6 = append(backendAddressPoolsV6,
+					network.BackendAddressPool{
+						ID: (*lb.BackendAddressPools)[i].ID,
+					})
+			} else {
+				backendAddressPools = append(backendAddressPools,
+					network.BackendAddressPool{
+						ID: (*lb.BackendAddressPools)[i].ID,
+					})
+			}
+
+			if nicSpec.NatRule != nil {
+				if ipConfig.PrivateIPAddressVersion == network.IPv6 {
+					loadBalancerInboundNatRulesV6 = append(loadBalancerInboundNatRulesV6,
+						network.InboundNatRule{ID: (*lb.InboundNatRules)[*nicSpec.NatRule].ID})
+				} else {
+					loadBalancerInboundNatRules = append(loadBalancerInboundNatRules,
+						network.InboundNatRule{ID: (*lb.InboundNatRules)[*nicSpec.NatRule].ID})
+				}
 			}
 		}
+
+		if nicSpec.NatRule != nil {
+			nicConfig.LoadBalancerInboundNatRules = &loadBalancerInboundNatRules
+			nicConfigV6.LoadBalancerInboundNatRules = &loadBalancerInboundNatRulesV6
+		}
+
 	}
 	if nicSpec.InternalLoadBalancerName != "" {
 		internallbInterface, ilberr := internalloadbalancers.NewService(s.Scope).Get(ctx, &internalloadbalancers.Spec{Name: nicSpec.InternalLoadBalancerName})
@@ -137,13 +188,31 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		if !ok {
 			return errors.New("internal load balancer get returned invalid network interface")
 		}
-		backendAddressPools = append(backendAddressPools,
-			network.BackendAddressPool{
-				ID: (*internallb.BackendAddressPools)[0].ID,
-			})
+		// loadbalancers can have multiple frontends and backends with different IP families
+		for i, ipConfig := range *internallb.FrontendIPConfigurations {
+			// iterate only for the frontends that have backends configured
+			if i >= len(*internallb.BackendAddressPools) {
+				break
+			}
+			if ipConfig.PrivateIPAddressVersion == network.IPv6 {
+				backendAddressPoolsV6 = append(backendAddressPoolsV6,
+					network.BackendAddressPool{
+						ID: (*internallb.BackendAddressPools)[i].ID,
+					})
+			} else {
+				backendAddressPools = append(backendAddressPools,
+					network.BackendAddressPool{
+						ID: (*internallb.BackendAddressPools)[i].ID,
+					})
+			}
+		}
 	}
 	nicConfig.LoadBalancerBackendAddressPools = &backendAddressPools
+	if nicHasIPv6 {
+		nicConfigV6.LoadBalancerBackendAddressPools = &backendAddressPoolsV6
+	}
 
+	// security groups
 	if nicSpec.SecurityGroupName != "" {
 		securityGroupInterface, sgerr := securitygroups.NewService(s.Scope).Get(ctx, &securitygroups.Spec{Name: nicSpec.SecurityGroupName})
 		if sgerr != nil {
@@ -177,6 +246,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		nicConfig.ApplicationSecurityGroups = &groups
 	}
 
+	// configure the nic with the corresponding IP configurations
 	nicProp.IPConfigurations = &[]network.InterfaceIPConfiguration{
 		{
 			Name:                                     to.StringPtr("pipConfig"),
@@ -184,18 +254,11 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		},
 	}
 
-	if subnetHasIPv6(subnet) {
-		klog.V(2).Infof("Found IPv6 address space. Adding IPv6 configuration to nic: %s", nicSpec.Name)
-		nicConfigIPv6 := &network.InterfaceIPConfigurationPropertiesFormat{}
-
-		nicConfigIPv6.Subnet = &network.Subnet{ID: subnet.ID}
-		nicConfigIPv6.PrivateIPAllocationMethod = network.Dynamic
-		nicConfigIPv6.PrivateIPAddressVersion = network.IPv6
-
+	if nicHasIPv6 {
 		ipConfigs := append(*nicProp.IPConfigurations,
 			network.InterfaceIPConfiguration{
 				Name:                                     to.StringPtr("pipConfig-v6"),
-				InterfaceIPConfigurationPropertiesFormat: nicConfigIPv6,
+				InterfaceIPConfigurationPropertiesFormat: nicConfigV6,
 			},
 		)
 
@@ -268,16 +331,9 @@ func subnetHasIPv6(subnet network.Subnet) bool {
 	}
 
 	for _, prefix := range prefixes {
-		ip, _, err := net.ParseCIDR(prefix)
-		if err != nil {
-			klog.Errorf("Error parsing subnet address prefix: %v", err)
-			continue
-		}
-
-		if ip != nil && ip.To4() == nil {
-			return true // Found an IPv6 subnet.
+		if utilnet.IsIPv6CIDRString(prefix) {
+			return true
 		}
 	}
-
 	return false
 }

--- a/vendor/k8s.io/utils/net/ipnet.go
+++ b/vendor/k8s.io/utils/net/ipnet.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IPNetSet maps string to net.IPNet.
+type IPNetSet map[string]*net.IPNet
+
+// ParseIPNets parses string slice to IPNetSet.
+func ParseIPNets(specs ...string) (IPNetSet, error) {
+	ipnetset := make(IPNetSet)
+	for _, spec := range specs {
+		spec = strings.TrimSpace(spec)
+		_, ipnet, err := net.ParseCIDR(spec)
+		if err != nil {
+			return nil, err
+		}
+		k := ipnet.String() // In case of normalization
+		ipnetset[k] = ipnet
+	}
+	return ipnetset, nil
+}
+
+// Insert adds items to the set.
+func (s IPNetSet) Insert(items ...*net.IPNet) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPNetSet) Delete(items ...*net.IPNet) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPNetSet) Has(item *net.IPNet) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPNetSet) HasAll(items ...*net.IPNet) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPNetSet) Difference(s2 IPNetSet) IPNetSet {
+	result := make(IPNetSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPNetSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPNetSet) IsSuperset(s2 IPNetSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPNetSet) Equal(s2 IPNetSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPNetSet) Len() int {
+	return len(s)
+}
+
+// IPSet maps string to net.IP
+type IPSet map[string]net.IP
+
+// ParseIPSet parses string slice to IPSet
+func ParseIPSet(items ...string) (IPSet, error) {
+	ipset := make(IPSet)
+	for _, item := range items {
+		ip := net.ParseIP(strings.TrimSpace(item))
+		if ip == nil {
+			return nil, fmt.Errorf("error parsing IP %q", item)
+		}
+
+		ipset[ip.String()] = ip
+	}
+
+	return ipset, nil
+}
+
+// Insert adds items to the set.
+func (s IPSet) Insert(items ...net.IP) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPSet) Delete(items ...net.IP) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPSet) Has(item net.IP) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPSet) HasAll(items ...net.IP) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPSet) Difference(s2 IPSet) IPSet {
+	result := make(IPSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPSet) IsSuperset(s2 IPSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPSet) Equal(s2 IPSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPSet) Len() int {
+	return len(s)
+}

--- a/vendor/k8s.io/utils/net/net.go
+++ b/vendor/k8s.io/utils/net/net.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strconv"
+)
+
+// ParseCIDRs parses a list of cidrs and return error if any is invalid.
+// order is maintained
+func ParseCIDRs(cidrsString []string) ([]*net.IPNet, error) {
+	cidrs := make([]*net.IPNet, 0, len(cidrsString))
+	for _, cidrString := range cidrsString {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cidr value:%q with error:%v", cidrString, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	return cidrs, nil
+}
+
+// IsDualStackIPs returns if a slice of ips is:
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPs(ips []net.IP) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, ip := range ips {
+		if ip == nil {
+			return false, fmt.Errorf("ip %v is invalid", ip)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(ip) {
+			v6Found = true
+			continue
+		}
+
+		v4Found = true
+	}
+
+	return (v4Found && v6Found), nil
+}
+
+// IsDualStackIPStrings returns if
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPStrings(ips []string) (bool, error) {
+	parsedIPs := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		parsedIPs = append(parsedIPs, parsedIP)
+	}
+	return IsDualStackIPs(parsedIPs)
+}
+
+// IsDualStackCIDRs returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRs(cidrs []*net.IPNet) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, cidr := range cidrs {
+		if cidr == nil {
+			return false, fmt.Errorf("cidr %v is invalid", cidr)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(cidr.IP) {
+			v6Found = true
+			continue
+		}
+		v4Found = true
+	}
+
+	return v4Found && v6Found, nil
+}
+
+// IsDualStackCIDRStrings returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRStrings(cidrs []string) (bool, error) {
+	parsedCIDRs, err := ParseCIDRs(cidrs)
+	if err != nil {
+		return false, err
+	}
+	return IsDualStackCIDRs(parsedCIDRs)
+}
+
+// IsIPv6 returns if netIP is IPv6.
+func IsIPv6(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() == nil
+}
+
+// IsIPv6String returns if ip is IPv6.
+func IsIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv6(netIP)
+}
+
+// IsIPv6CIDRString returns if cidr is IPv6.
+// This assumes cidr is a valid CIDR.
+func IsIPv6CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv6(ip)
+}
+
+// IsIPv6CIDR returns if a cidr is ipv6
+func IsIPv6CIDR(cidr *net.IPNet) bool {
+	ip := cidr.IP
+	return IsIPv6(ip)
+}
+
+// IsIPv4 returns if netIP is IPv4.
+func IsIPv4(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() != nil
+}
+
+// IsIPv4String returns if ip is IPv4.
+func IsIPv4String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv4(netIP)
+}
+
+// IsIPv4CIDR returns if a cidr is ipv4
+func IsIPv4CIDR(cidr *net.IPNet) bool {
+	ip := cidr.IP
+	return IsIPv4(ip)
+}
+
+// IsIPv4CIDRString returns if cidr is IPv4.
+// This assumes cidr is a valid CIDR.
+func IsIPv4CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv4(ip)
+}
+
+// ParsePort parses a string representing an IP port.  If the string is not a
+// valid port number, this returns an error.
+func ParsePort(port string, allowZero bool) (int, error) {
+	portInt, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	if portInt == 0 && !allowZero {
+		return 0, errors.New("0 is not a valid port number")
+	}
+	return int(portInt), nil
+}
+
+// BigForIP creates a big.Int based on the provided net.IP
+func BigForIP(ip net.IP) *big.Int {
+	// NOTE: Convert to 16-byte representation so we can
+	// handle v4 and v6 values the same way.
+	return big.NewInt(0).SetBytes(ip.To16())
+}
+
+// AddIPOffset adds the provided integer offset to a base big.Int representing a net.IP
+// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
+func AddIPOffset(base *big.Int, offset int) net.IP {
+	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
+	r = append(make([]byte, 16), r...)
+	return net.IP(r[len(r)-16:])
+}
+
+// RangeSize returns the size of a range in valid addresses.
+// returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
+func RangeSize(subnet *net.IPNet) int64 {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// this checks that we are not overflowing an int64
+	if bits-ones >= 63 {
+		return math.MaxInt64
+	}
+	return int64(1) << uint(bits-ones)
+}
+
+// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := AddIPOffset(BigForIP(subnet.IP), index)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}

--- a/vendor/k8s.io/utils/net/port.go
+++ b/vendor/k8s.io/utils/net/port.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// IPFamily refers to a specific family if not empty, i.e. "4" or "6".
+type IPFamily string
+
+// Constants for valid IPFamilys:
+const (
+	IPv4 IPFamily = "4"
+	IPv6          = "6"
+)
+
+// Protocol is a network protocol support by LocalPort.
+type Protocol string
+
+// Constants for valid protocols:
+const (
+	TCP Protocol = "TCP"
+	UDP Protocol = "UDP"
+)
+
+// LocalPort represents an IP address and port pair along with a protocol
+// and potentially a specific IP family.
+// A LocalPort can be opened and subsequently closed.
+type LocalPort struct {
+	// Description is an arbitrary string.
+	Description string
+	// IP is the IP address part of a given local port.
+	// If this string is empty, the port binds to all local IP addresses.
+	IP string
+	// If IPFamily is not empty, the port binds only to addresses of this
+	// family.
+	// IF empty along with IP, bind to local addresses of any family.
+	IPFamily IPFamily
+	// Port is the port number.
+	// A value of 0 causes a port to be automatically chosen.
+	Port int
+	// Protocol is the protocol, e.g. TCP
+	Protocol Protocol
+}
+
+// NewLocalPort returns a LocalPort instance and ensures IPFamily and IP are
+// consistent and that the given protocol is valid.
+func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol Protocol) (*LocalPort, error) {
+	if protocol != TCP && protocol != UDP {
+		return nil, fmt.Errorf("Unsupported protocol %s", protocol)
+	}
+	if ipFamily != "" && ipFamily != "4" && ipFamily != "6" {
+		return nil, fmt.Errorf("Invalid IP family %s", ipFamily)
+	}
+	if ip != "" {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			return nil, fmt.Errorf("invalid ip address %s", ip)
+		}
+		asIPv4 := parsedIP.To4()
+		if asIPv4 == nil && ipFamily == IPv4 || asIPv4 != nil && ipFamily == IPv6 {
+			return nil, fmt.Errorf("ip address and family mismatch %s, %s", ip, ipFamily)
+		}
+	}
+	return &LocalPort{Description: desc, IP: ip, IPFamily: ipFamily, Port: port, Protocol: protocol}, nil
+}
+
+func (lp *LocalPort) String() string {
+	ipPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	return fmt.Sprintf("%q (%s/%s%s)", lp.Description, ipPort, strings.ToLower(string(lp.Protocol)), lp.IPFamily)
+}
+
+// Closeable closes an opened LocalPort.
+type Closeable interface {
+	Close() error
+}
+
+// PortOpener can open a LocalPort and allows later closing it.
+type PortOpener interface {
+	OpenLocalPort(lp *LocalPort) (Closeable, error)
+}
+
+type listenPortOpener struct{}
+
+// ListenPortOpener opens ports by calling bind() and listen().
+var ListenPortOpener listenPortOpener
+
+// OpenLocalPort holds the given local port open.
+func (l *listenPortOpener) OpenLocalPort(lp *LocalPort) (Closeable, error) {
+	return openLocalPort(lp)
+}
+
+func openLocalPort(lp *LocalPort) (Closeable, error) {
+	var socket Closeable
+	hostPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	switch lp.Protocol {
+	case TCP:
+		network := "tcp" + string(lp.IPFamily)
+		listener, err := net.Listen(network, hostPort)
+		if err != nil {
+			return nil, err
+		}
+		socket = listener
+	case UDP:
+		network := "udp" + string(lp.IPFamily)
+		addr, err := net.ResolveUDPAddr(network, hostPort)
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP(network, addr)
+		if err != nil {
+			return nil, err
+		}
+		socket = conn
+	default:
+		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
+	}
+	return socket, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -654,6 +654,7 @@ k8s.io/kubectl/pkg/validation
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
+k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/cluster-api-provider-aws v0.0.0-00010101000000-000000000000 => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20201125052318-b85a18cbf338


### PR DESCRIPTION
**What this PR does / why we need it**:

Current dual-stack support fails when there are loadbalancers associated to the VMs, because load balancers implement different backends per IP family.

This causes that when a loadbalancer with multiples IPs is associates to a dual stack VM, the VM interfaces is added to a backend with different IP family, causing that the VM can not be created

```
I0317 22:42:50.679720       1 networkinterfaces.go:188] Found IPv6 address space. Adding IPv6 configuration to nic: aojeadual-wzzqr-worker-centralus2-dzlvq-nic
I0317 22:42:51.230128       1 machine_scope.go:160] aojeadual-wzzqr-worker-centralus2-dzlvq: patching machine
E0317 22:42:51.295170       1 actuator.go:78] Machine error: failed to reconcile machine "aojeadual-wzzqr-worker-centralus2-dzlvq": network.InterfacesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="AllNicIpConfigurationsOfLbBackendPoolMustHaveSamePrivateIpAddressVersion" Message="Network interface ipConfiguration '/subscriptions/5970b0fe-21de-4e1a-a192-0a785017e3b7/resourceGroups/aojeadual-wzzqr-rg/providers/Microsoft.Network/networkInterfaces/aojeadual-wzzqr-worker-centralus2-dzlvq-nic/ipConfigurations/pipConfig' with privateIpAddressVersion 'IPv4' does not match with privateIpAddressVersion 'IPv6' of network interface ipConfiguration '/subscriptions/5970b0fe-21de-4e1a-a192-0a785017e3b7/resourceGroups/aojeadual-wzzqr-rg/providers/Microsoft.Network/networkInterfaces/aojeadual-wzzqr-master0-nic/ipConfigurations/pipConfig-v6' in the load balancer backend address pool '/subscriptions/5970b0fe-21de-4e1a-a192-0a785017e3b7/resourceGroups/aojeadual-wzzqr-rg/providers/Microsoft.Network/loadBalancers/aojeadual-wzzqr/backendAddressPools/aojeadual-wzzqr-IPv6'." Details=[]
```


```release-note
Fix dual-stack support when load balancers are associated to the interfaces
```