### PR TITLE
Bug 1910318: Ensure original conditions aren't mutated during reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v0.0.0-20201216151826-78a19e96f9eb
-	github.com/openshift/machine-api-operator v0.2.1-0.20210310053650-d40398c49baf
+	github.com/openshift/machine-api-operator v0.2.1-0.20210322142500-9101e75223bf
 	github.com/spf13/cobra v1.1.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 

--- a/go.sum
+++ b/go.sum
@@ -565,8 +565,8 @@ github.com/openshift/machine-api-operator v0.2.1-0.20200926044412-b7d860f8074c h
 github.com/openshift/machine-api-operator v0.2.1-0.20200926044412-b7d860f8074c/go.mod h1:cp/wPVzxHZeLUjOLkNPNqrk4wyyW6HuHd3Kz9+hl5xw=
 github.com/openshift/machine-api-operator v0.2.1-0.20201002104344-6abfb5440597 h1:2leDrsKmE7ppJSthf6SiD+Pqjyis633L/n+YdTVdBbo=
 github.com/openshift/machine-api-operator v0.2.1-0.20201002104344-6abfb5440597/go.mod h1:+oAfoCl+TUd2TM79/6NdqLpFUHIJpmqkKdmiHe2O7mw=
-github.com/openshift/machine-api-operator v0.2.1-0.20210310053650-d40398c49baf h1:C4nn2kbSDhLXwg7W87EgcDpri83QnGSbH1C0cqJxHgI=
-github.com/openshift/machine-api-operator v0.2.1-0.20210310053650-d40398c49baf/go.mod h1:N3Q+UKEziycun6J3kyxQnRsBBebjwm9fnD6vSnUWqRU=
+github.com/openshift/machine-api-operator v0.2.1-0.20210322142500-9101e75223bf h1:R9HI45C81V4cGbXmMF6+9NXk7d54T5sfTs84gIrBq0w=
+github.com/openshift/machine-api-operator v0.2.1-0.20210322142500-9101e75223bf/go.mod h1:N3Q+UKEziycun6J3kyxQnRsBBebjwm9fnD6vSnUWqRU=
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,7 +189,7 @@ github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 # github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201201000827-1117a4fc438c
 github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
-# github.com/openshift/machine-api-operator v0.2.1-0.20210310053650-d40398c49baf
+# github.com/openshift/machine-api-operator v0.2.1-0.20210322142500-9101e75223bf
 ## explicit
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1


### PR DESCRIPTION
Vendor update for fix:
> If the original conditions are just fetched directly from the machine, this is a reference to a slice. This slice can then be updated by updating the machine conditions. We need to instead have a copy, else the comparison later won't work.
>
>Also, if we mark the condition true then call the actuator update, this can cause issues as the actuator may also patch the machine (eg for providerID). So this needs to come after.
>
>Tested manually on AWS.