### PR TITLE
Bug 1918910: Only log error on wrong instance type for scale from zero

### DIFF
--- a/pkg/cloud/azure/actuators/machineset/controller.go
+++ b/pkg/cloud/azure/actuators/machineset/controller.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -89,7 +90,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	originalMachineSetToPatch := client.MergeFrom(machineSet.DeepCopy())
 
-	result, err := reconcile(machineSet)
+	result, err := r.reconcile(machineSet)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile MachineSet")
 		r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "ReconcileError", "%v", err)
@@ -119,14 +120,19 @@ func isInvalidConfigurationError(err error) bool {
 	return false
 }
 
-func reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, error) {
+func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, error) {
 	providerConfig, err := getproviderConfig(machineSet)
 	if err != nil {
 		return ctrl.Result{}, mapierrors.InvalidMachineConfiguration("failed to get providerConfig: %v", err)
 	}
 	instanceType, ok := InstanceTypes[providerConfig.VMSize]
 	if !ok {
-		return ctrl.Result{}, mapierrors.InvalidMachineConfiguration("unknown instance type: %s", providerConfig.VMSize)
+		klog.Error("Unable to set scale from zero annotations: unknown instance type: %s", providerConfig.VMSize)
+		klog.Error("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{cpuKey, memoryKey, gpuKey})
+
+		// Returning no error to prevent further reconciliation, as user intervention is now required but emit an informational event
+		r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "FailedUpdate", "Failed to set autoscaling from zero annotations, instance type unknown")
+		return ctrl.Result{}, nil
 	}
 
 	if machineSet.Annotations == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent endless reconciles for machineSet due to failed attempt to set scale from zero annotation when the instance type is missing in our static list.
