### PR TITLE
[RFE-793] Create availability sets when needed

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -730,6 +730,11 @@ func (s *Reconciler) createAvailabilitySet() (string, error) {
 		return "", nil
 	}
 
+	if _, ok := s.scope.Machine.Labels[MachineSetLabelName]; !ok {
+		klog.V(4).Infof("MachineSet label name was not found for %s, skipping availability set creation", s.scope.Machine.Name)
+		return "", nil
+	}
+
 	klog.V(4).Infof("No availability zones were found for %s, an availability set will be created", s.scope.Machine.Name)
 
 	if err := s.availabilitySetsSvc.CreateOrUpdate(context.Background(), availabilitysets.Spec{

--- a/pkg/cloud/azure/services/availabilitysets/availabilitysets.go
+++ b/pkg/cloud/azure/services/availabilitysets/availabilitysets.go
@@ -1,0 +1,93 @@
+package availabilitysets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
+)
+
+// Spec input specification for Get/CreateOrUpdate/Delete calls
+type Spec struct {
+	Name string
+}
+
+// CreateOrUpdate creates or updates the availability set with the given name.
+func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
+	availabilitysetsSpec, ok := spec.(*Spec)
+	if !ok {
+		return errors.New("invalid availability set specification")
+	}
+
+	asParams := compute.AvailabilitySet{
+		Name: to.StringPtr(availabilitysetsSpec.Name),
+		Sku: &compute.Sku{
+			Name: to.StringPtr(string(compute.AvailabilitySetSkuTypesAligned)),
+		},
+		Location: to.StringPtr(s.Scope.Location()),
+		AvailabilitySetProperties: &compute.AvailabilitySetProperties{
+			PlatformFaultDomainCount:  to.Int32Ptr(int32(2)),
+			PlatformUpdateDomainCount: to.Int32Ptr(int32(5)),
+		},
+	}
+
+	_, err := s.Client.CreateOrUpdate(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name, asParams)
+	if err != nil {
+		return fmt.Errorf("failed to create availability set %s: %w", availabilitysetsSpec.Name, err)
+	}
+
+	return nil
+}
+
+// Get returns the availability set with the given name.
+func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error) {
+	availabilitysetsSpec, ok := spec.(*Spec)
+	if !ok {
+		return nil, errors.New("invalid availability set specification")
+	}
+
+	as, err := s.Client.Get(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get availability set %s: %w", availabilitysetsSpec.Name, err)
+	}
+
+	return as, nil
+}
+
+// Delete deletes the availability set with the given name if no virtual machines are attached to it.
+func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
+	availabilitysetsSpec, ok := spec.(*Spec)
+	if !ok {
+		return errors.New("invalid availability set specification")
+	}
+
+	as, err := s.Client.Get(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name)
+	if err != nil && azure.ResourceNotFound(err) {
+		// already deleted
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to get availability set %s: %w", availabilitysetsSpec.Name, err)
+	}
+
+	// only delete when the availability set does not have any vms
+	if as.AvailabilitySetProperties != nil && as.VirtualMachines != nil && len(*as.VirtualMachines) > 0 {
+		return nil
+	}
+
+	_, err = s.Client.Delete(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name)
+	if err != nil && azure.ResourceNotFound(err) {
+		// already deleted
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to delete availability set %s: %w", availabilitysetsSpec.Name, err)
+	}
+
+	return nil
+}

--- a/pkg/cloud/azure/services/availabilitysets/service.go
+++ b/pkg/cloud/azure/services/availabilitysets/service.go
@@ -1,0 +1,30 @@
+package availabilitysets
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/actuators"
+)
+
+// Service provides operations on availability zones
+type Service struct {
+	Client compute.AvailabilitySetsClient
+	Scope  *actuators.MachineScope
+}
+
+// getAvailabilitySetsClient creates a new availability zones client from subscriptionid.
+func getAvailabilitySetsClient(resourceManagerEndpoint, subscriptionID string, authorizer autorest.Authorizer) compute.AvailabilitySetsClient {
+	availabilitySetClient := compute.NewAvailabilitySetsClientWithBaseURI(resourceManagerEndpoint, subscriptionID)
+	availabilitySetClient.Authorizer = authorizer
+	availabilitySetClient.AddToUserAgent(azure.UserAgent)
+	return availabilitySetClient
+}
+
+// NewService creates a new availability zones service.
+func NewService(scope *actuators.MachineScope) azure.Service {
+	return &Service{
+		Client: getAvailabilitySetsClient(scope.ResourceManagerEndpoint, scope.SubscriptionID, scope.Authorizer),
+		Scope:  scope,
+	}
+}

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_test.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_test.go
@@ -101,7 +101,7 @@ func TestDeriveVirtualMachineParameters(t *testing.T) {
 			location := "eastus"
 			nic := getTestNic(vmSpec, subscription, resourcegroup, location)
 
-			vm, err := deriveVirtualMachineParameters(vmSpec, location, subscription, nic)
+			vm, err := deriveVirtualMachineParameters(vmSpec, location, subscription, resourcegroup, nic)
 
 			g.Expect(err).ToNot(HaveOccurred())
 			tc.validate(g, vm)


### PR DESCRIPTION
This is useful when azure region does not have multiple zones but supports availability sets. Our controller will detect that the region has no zone and create an availability set for each machine set.
Note: availability set also gets deleted along with the resource group during cluster deletion.