### PR TITLE
Bug 1988992: Create event only if the machine was modified

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -187,11 +187,18 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error
 		}
 	}
 
+	previousResourceVersion := scope.Machine.ResourceVersion
+
 	if err := scope.Persist(); err != nil {
 		return fmt.Errorf("error storing machine info: %v", err)
 	}
 
-	a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Updated", "Updated machine %q", machine.Name)
+	currentResourceVersion := scope.Machine.ResourceVersion
+
+	// Create event only if machine object was modified
+	if previousResourceVersion != currentResourceVersion {
+		a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Updated", "Updated machine %q", machine.Name)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Now Azure actuator always creates an event after Update, even though the change might not have happened.

To prevent creating fake events we compare machine resource version before and after update, and create an event only if they are different.