### PR TITLE
Bug 2021322: Azure Marketplace Purchase Plan Info

### DIFF
--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -304,6 +304,17 @@ func (s *Service) deriveVirtualMachineParameters(vmSpec *Spec, nic network.Inter
 		}
 	}
 
+	// When a SKU, Offer, & Publisher are specified in the ImageReference, the VM will
+	// use an Azure Marketplace image. RHCOS marketplace images require a purchase plan:
+	// For more information, see the second example here:
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#deploy-a-new-vm-using-the-image-parameters
+	if virtualMachine.StorageProfile.ImageReference.Sku != nil {
+		virtualMachine.Plan = &compute.Plan{
+			Name:      virtualMachine.StorageProfile.ImageReference.Sku,
+			Product:   virtualMachine.StorageProfile.ImageReference.Offer,
+			Publisher: virtualMachine.StorageProfile.ImageReference.Publisher,
+		}
+	}
 	return virtualMachine, nil
 }
 


### PR DESCRIPTION
The `MachineSpec` allows passing the `imageReference` fields to specify an image from the Azure Marketplace:

```go
// ImageReference specifies information about the image to use. You can specify information about platform
// images, marketplace images, or virtual machine images. This element is required when you want to use a
// platform image, marketplace image, or virtual machine image, but is not used in other creation
// operations. NOTE: Image reference publisher and offer can only be set when you create the scale set.
type ImageReference struct {
	// Publisher - The image publisher.
	Publisher *string `json:"publisher,omitempty"`
	// Offer - Specifies the offer of the platform image or marketplace image used to create the virtual machine.
	Offer *string `json:"offer,omitempty"`
	// Sku - The image SKU.
	Sku *string `json:"sku,omitempty"`
	// Version - Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
	Version *string `json:"version,omitempty"`
	// ExactVersion - READ-ONLY; Specifies in decimal numbers, the version of platform image or marketplace image used to create the virtual machine. This readonly field differs from 'version', only if the value specified in 'version' field is 'latest'.
	ExactVersion *string `json:"exactVersion,omitempty"`
	// ID - Resource Id
	ID *string `json:"id,omitempty"`
}
```

When trying to use these fields to create a VM, we are hitting the error
```
Failed
padillon-azmkt-8qplf-worker-fc1-eastus3-97wg8
Additional error information is available for this virtual machine:
GENERAL
Provisioning state Provisioning failed.
Creating a virtual machine from Marketplace image or a custom image sourced from a Marketplace image requires Plan information in the request. VM: '/subscriptions/433715e6-37fe-4328-af75-3661e13b15fc/resourceGroups/padillon-azmkt-8qplf-rg/providers/Microsoft.Compute/virtualMachines/padillon-azmkt-8qplf-worker-fc1-eastus3-97wg8'..
VMMarketplaceInvalidInput
Provisioning state error code ProvisioningState/failed/VMMarketplaceInvalidInput
Guest agent Unknown
DISKS
padillon-azmkt-8qplf-worker-fc1-eastus3-97wg8_OSDisk Provisioning failed.
Creating a virtual machine from Marketplace image or a custom image sourced from a Marketplace image requires Plan information in the request. VM: '/subscriptions/433715e6-37fe-4328-af75-3661e13b15fc/resourceGroups/padillon-azmkt-8qplf-rg/providers/Microsoft.Compute/virtualMachines/padillon-azmkt-8qplf-worker-fc1-eastus3-97wg8'..
VMMarketplaceInvalidInput
```

This PR adds the plan information to the VM.
