### PR TITLE
Revert "Bug 2021322: Azure Marketplace Purchase Plan Info"

### DIFF
--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -304,17 +304,6 @@ func (s *Service) deriveVirtualMachineParameters(vmSpec *Spec, nic network.Inter
 		}
 	}
 
-	// When a SKU, Offer, & Publisher are specified in the ImageReference, the VM will
-	// use an Azure Marketplace image. RHCOS marketplace images require a purchase plan:
-	// For more information, see the second example here:
-	// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#deploy-a-new-vm-using-the-image-parameters
-	if virtualMachine.StorageProfile.ImageReference.Sku != nil {
-		virtualMachine.Plan = &compute.Plan{
-			Name:      virtualMachine.StorageProfile.ImageReference.Sku,
-			Product:   virtualMachine.StorageProfile.ImageReference.Offer,
-			Publisher: virtualMachine.StorageProfile.ImageReference.Publisher,
-		}
-	}
 	return virtualMachine, nil
 }
 


### PR DESCRIPTION
Reverts openshift/cluster-api-provider-azure#237

It was highlighted via slack that the current fix does not work for marketplace images that are free. This is causing issues for existing images that are using the marketplace, eg [WMCO CI](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_windows-machine-config-operator/777/pull-ci-openshift-windows-machine-config-operator-master-azure-e2e-operator/1458253671316852736/artifacts/azure-e2e-operator/gather-extra/artifacts/pods/openshift-machine-api_machine-api-controllers-577ddc7489-n8v7w_machine-controller.log)

We need to find a way to make this work with free and paid images 