### PR TITLE
UPSTREAM: <carry>: Don't ignore kubeconfig package in vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ envfile
 kind.kubeconfig
 minikube.kubeconfig
 kubeconfig
+!kubeconfig/
 
 # ssh keys
 .ssh*

--- a/vendor/sigs.k8s.io/cluster-api/util/kubeconfig/kubeconfig.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/kubeconfig/kubeconfig.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfig implements utilities for working with kubeconfigs.
+package kubeconfig
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/certs"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// ErrDependentCertificateNotFound signals that a CA secret could not be found.
+	ErrDependentCertificateNotFound = errors.New("could not find secret ca")
+)
+
+// FromSecret fetches the Kubeconfig for a Cluster.
+func FromSecret(ctx context.Context, c client.Reader, cluster client.ObjectKey) ([]byte, error) {
+	out, err := secret.Get(ctx, c, cluster, secret.Kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return toKubeconfigBytes(out)
+}
+
+// New creates a new Kubeconfig using the cluster name and specified endpoint.
+func New(clusterName, endpoint string, caCert *x509.Certificate, caKey crypto.Signer) (*api.Config, error) {
+	cfg := &certs.Config{
+		CommonName:   "kubernetes-admin",
+		Organization: []string{"system:masters"},
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientKey, err := certs.NewPrivateKey()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create private key")
+	}
+
+	clientCert, err := cfg.NewSignedCert(clientKey, caCert, caKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to sign certificate")
+	}
+
+	userName := fmt.Sprintf("%s-admin", clusterName)
+	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
+
+	return &api.Config{
+		Clusters: map[string]*api.Cluster{
+			clusterName: {
+				Server:                   endpoint,
+				CertificateAuthorityData: certs.EncodeCertPEM(caCert),
+			},
+		},
+		Contexts: map[string]*api.Context{
+			contextName: {
+				Cluster:  clusterName,
+				AuthInfo: userName,
+			},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			userName: {
+				ClientKeyData:         certs.EncodePrivateKeyPEM(clientKey),
+				ClientCertificateData: certs.EncodeCertPEM(clientCert),
+			},
+		},
+		CurrentContext: contextName,
+	}, nil
+}
+
+// CreateSecret creates the Kubeconfig secret for the given cluster.
+func CreateSecret(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) error {
+	name := util.ObjectKey(cluster)
+	return CreateSecretWithOwner(ctx, c, name, cluster.Spec.ControlPlaneEndpoint.String(), metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	})
+}
+
+// CreateSecretWithOwner creates the Kubeconfig secret for the given cluster name, namespace, endpoint, and owner reference.
+func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string, owner metav1.OwnerReference) error {
+	server := fmt.Sprintf("https://%s", endpoint)
+	out, err := generateKubeconfig(ctx, c, clusterName, server)
+	if err != nil {
+		return err
+	}
+
+	return c.Create(ctx, GenerateSecretWithOwner(clusterName, out, owner))
+}
+
+// GenerateSecret returns a Kubernetes secret for the given Cluster and kubeconfig data.
+func GenerateSecret(cluster *clusterv1.Cluster, data []byte) *corev1.Secret {
+	name := util.ObjectKey(cluster)
+	return GenerateSecretWithOwner(name, data, metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	})
+}
+
+// GenerateSecretWithOwner returns a Kubernetes secret for the given Cluster name, namespace, kubeconfig data, and ownerReference.
+func GenerateSecretWithOwner(clusterName client.ObjectKey, data []byte, owner metav1.OwnerReference) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
+			Namespace: clusterName.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: clusterName.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				owner,
+			},
+		},
+		Data: map[string][]byte{
+			secret.KubeconfigDataName: data,
+		},
+		Type: clusterv1.ClusterSecretType,
+	}
+}
+
+// NeedsClientCertRotation returns whether any of the Kubeconfig secret's client certificates will expire before the given threshold.
+func NeedsClientCertRotation(configSecret *corev1.Secret, threshold time.Duration) (bool, error) {
+	now := time.Now()
+
+	data, err := toKubeconfigBytes(configSecret)
+	if err != nil {
+		return false, err
+	}
+
+	config, err := clientcmd.Load(data)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to convert kubeconfig Secret into a clientcmdapi.Config")
+	}
+
+	for _, authInfo := range config.AuthInfos {
+		cert, err := certs.DecodeCertPEM(authInfo.ClientCertificateData)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to decode kubeconfig client certificate")
+		}
+		if cert.NotAfter.Sub(now) < threshold {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// RegenerateSecret creates and stores a new Kubeconfig in the given secret.
+func RegenerateSecret(ctx context.Context, c client.Client, configSecret *corev1.Secret) error {
+	clusterName, _, err := secret.ParseSecretName(configSecret.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse secret name")
+	}
+	data, err := toKubeconfigBytes(configSecret)
+	if err != nil {
+		return err
+	}
+
+	config, err := clientcmd.Load(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert kubeconfig Secret into a clientcmdapi.Config")
+	}
+	endpoint := config.Clusters[clusterName].Server
+	key := client.ObjectKey{Name: clusterName, Namespace: configSecret.Namespace}
+	out, err := generateKubeconfig(ctx, c, key, endpoint)
+	if err != nil {
+		return err
+	}
+	configSecret.Data[secret.KubeconfigDataName] = out
+	return c.Update(ctx, configSecret)
+}
+
+func generateKubeconfig(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string) ([]byte, error) {
+	clusterCA, err := secret.GetFromNamespacedName(ctx, c, clusterName, secret.ClusterCA)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, ErrDependentCertificateNotFound
+		}
+		return nil, err
+	}
+
+	cert, err := certs.DecodeCertPEM(clusterCA.Data[secret.TLSCrtDataName])
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode CA Cert")
+	} else if cert == nil {
+		return nil, errors.New("certificate not found in config")
+	}
+
+	key, err := certs.DecodePrivateKeyPEM(clusterCA.Data[secret.TLSKeyDataName])
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode private key")
+	} else if key == nil {
+		return nil, errors.New("CA private key not found")
+	}
+
+	cfg, err := New(clusterName.Name, endpoint, cert, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate a kubeconfig")
+	}
+
+	out, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to serialize config to yaml")
+	}
+	return out, nil
+}
+
+func toKubeconfigBytes(out *corev1.Secret) ([]byte, error) {
+	data, ok := out.Data[secret.KubeconfigDataName]
+	if !ok {
+		return nil, errors.Errorf("missing key %q in secret data", secret.KubeconfigDataName)
+	}
+	return data, nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/kubeconfig/testing.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/kubeconfig/testing.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// FromEnvTestConfig returns a new Kubeconfig in byte form when running in envtest.
+func FromEnvTestConfig(cfg *rest.Config, cluster *clusterv1.Cluster) []byte {
+	contextName := fmt.Sprintf("%s@%s", cfg.Username, cluster.Name)
+	c := api.Config{
+		Clusters: map[string]*api.Cluster{
+			cluster.Name: {
+				Server:                   cfg.Host,
+				CertificateAuthorityData: cfg.CAData,
+			},
+		},
+		Contexts: map[string]*api.Context{
+			contextName: {
+				Cluster:  cluster.Name,
+				AuthInfo: cfg.Username,
+			},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			cfg.Username: {
+				ClientKeyData:         cfg.KeyData,
+				ClientCertificateData: cfg.CertData,
+			},
+		},
+		CurrentContext: contextName,
+	}
+	data, _ := clientcmd.Write(c)
+	return data
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"bytes"
+
+	yaml "gopkg.in/yaml.v3"
+	kubeyaml "sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// Encode encodes the cfg to yaml
+func Encode(cfg *Config) ([]byte, error) {
+	// NOTE: kubernetes's yaml library doesn't handle inline fields very well
+	// so we're not using that to marshal
+	encoded, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode KUBECONFIG")
+	}
+
+	// normalize with kubernetes's yaml library
+	// this is not strictly necessary, but it ensures minimal diffs when
+	// modifying kubeconfig files, which is nice to have
+	encoded, err = normYaml(encoded)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to normalize KUBECONFIG encoding")
+	}
+
+	return encoded, nil
+}
+
+// normYaml round trips yaml bytes through sigs.k8s.io/yaml to normalize them
+// versus other kubernetes ecosystem yaml output
+func normYaml(y []byte) ([]byte, error) {
+	var unstructured interface{}
+	if err := kubeyaml.Unmarshal(y, &unstructured); err != nil {
+		return nil, err
+	}
+	encoded, err := kubeyaml.Marshal(&unstructured)
+	if err != nil {
+		return nil, err
+	}
+	// special case: don't write anything when empty
+	if bytes.Equal(encoded, []byte("{}\n")) {
+		return []byte{}, nil
+	}
+	return encoded, nil
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/helpers.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/helpers.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// KINDClusterKey identifies kind clusters in kubeconfig files
+func KINDClusterKey(clusterName string) string {
+	return "kind-" + clusterName
+}
+
+// checkKubeadmExpectations validates that a kubeadm created KUBECONFIG meets
+// our expectations, namely on the number of entries
+func checkKubeadmExpectations(cfg *Config) error {
+	if len(cfg.Clusters) != 1 {
+		return errors.Errorf("kubeadm KUBECONFIG should have one cluster, but read %d", len(cfg.Clusters))
+	}
+	if len(cfg.Users) != 1 {
+		return errors.Errorf("kubeadm KUBECONFIG should have one user, but read %d", len(cfg.Users))
+	}
+	if len(cfg.Contexts) != 1 {
+		return errors.Errorf("kubeadm KUBECONFIG should have one context, but read %d", len(cfg.Contexts))
+	}
+	return nil
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/lock.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/lock.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// these are from
+// https://github.com/kubernetes/client-go/blob/611184f7c43ae2d520727f01d49620c7ed33412d/tools/clientcmd/loader.go#L439-L440
+
+func lockFile(filename string) error {
+	// Make sure the dir exists before we try to create a lock file.
+	dir := filepath.Dir(filename)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	f, err := os.OpenFile(lockName(filename), os.O_CREATE|os.O_EXCL, 0)
+	if err != nil {
+		return err
+	}
+	f.Close()
+	return nil
+}
+
+func unlockFile(filename string) error {
+	return os.Remove(lockName(filename))
+}
+
+func lockName(filename string) string {
+	return filename + ".lock"
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"os"
+
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// WriteMerged writes a kind kubeconfig (see KINDFromRawKubeadm) into configPath
+// merging with the existing contents if any and setting the current context to
+// the kind config's current context.
+func WriteMerged(kindConfig *Config, explicitConfigPath string) error {
+	// figure out what filepath we should use
+	configPath := pathForMerge(explicitConfigPath, os.Getenv)
+
+	// lock config file the same as client-go
+	if err := lockFile(configPath); err != nil {
+		return errors.Wrap(err, "failed to lock config file")
+	}
+	defer func() {
+		_ = unlockFile(configPath)
+	}()
+
+	// read in existing
+	existing, err := read(configPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to get kubeconfig to merge")
+	}
+
+	// merge with kind kubeconfig
+	if err := merge(existing, kindConfig); err != nil {
+		return err
+	}
+
+	// write back out
+	return write(existing, configPath)
+}
+
+// merge kind config into an existing config
+func merge(existing, kind *Config) error {
+	// verify assumptions about kubeadm / kind kubeconfigs
+	if err := checkKubeadmExpectations(kind); err != nil {
+		return err
+	}
+
+	// insert or append cluster entry
+	shouldAppend := true
+	for i := range existing.Clusters {
+		if existing.Clusters[i].Name == kind.Clusters[0].Name {
+			existing.Clusters[i] = kind.Clusters[0]
+			shouldAppend = false
+		}
+	}
+	if shouldAppend {
+		existing.Clusters = append(existing.Clusters, kind.Clusters[0])
+	}
+
+	// insert or append user entry
+	shouldAppend = true
+	for i := range existing.Users {
+		if existing.Users[i].Name == kind.Users[0].Name {
+			existing.Users[i] = kind.Users[0]
+			shouldAppend = false
+		}
+	}
+	if shouldAppend {
+		existing.Users = append(existing.Users, kind.Users[0])
+	}
+
+	// insert or append context entry
+	shouldAppend = true
+	for i := range existing.Contexts {
+		if existing.Contexts[i].Name == kind.Contexts[0].Name {
+			existing.Contexts[i] = kind.Contexts[0]
+			shouldAppend = false
+		}
+	}
+	if shouldAppend {
+		existing.Contexts = append(existing.Contexts, kind.Contexts[0])
+	}
+
+	// set the current context
+	existing.CurrentContext = kind.CurrentContext
+
+	// TODO: We should not need this, but it allows broken clients that depend
+	// on apiVersion and kind to work. Notably the upstream javascript client.
+	// See: https://github.com/kubernetes-sigs/kind/issues/1242
+	if len(existing.OtherFields) == 0 {
+		// TODO: Should we be deep-copying? for now we don't need to
+		// and doing so would be a pain (re and de-serialize maybe?) :shrug:
+		existing.OtherFields = kind.OtherFields
+	}
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const kubeconfigEnv = "KUBECONFIG"
+
+/*
+paths returns the list of paths to be considered for kubeconfig files
+where explicitPath is the value of --kubeconfig
+
+Logic based on kubectl
+
+https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands
+
+- If the --kubeconfig flag is set, then only that file is loaded. The flag may only be set once and no merging takes place.
+
+- If $KUBECONFIG environment variable is set, then it is used as a list of paths (normal path delimiting rules for your system). These paths are merged. When a value is modified, it is modified in the file that defines the stanza. When a value is created, it is created in the first file that exists. - If no files in the chain exist, then it creates the last file in the list.
+
+- Otherwise, ${HOME}/.kube/config is used and no merging takes place.
+*/
+func paths(explicitPath string, getEnv func(string) string) []string {
+	if explicitPath != "" {
+		return []string{explicitPath}
+	}
+
+	paths := discardEmptyAndDuplicates(
+		filepath.SplitList(getEnv(kubeconfigEnv)),
+	)
+	if len(paths) != 0 {
+		return paths
+	}
+
+	return []string{path.Join(homeDir(runtime.GOOS, getEnv), ".kube", "config")}
+}
+
+// pathForMerge returns the file that kubectl would merge into
+func pathForMerge(explicitPath string, getEnv func(string) string) string {
+	// find the first file that exists
+	p := paths(explicitPath, getEnv)
+	if len(p) == 1 {
+		return p[0]
+	}
+	for _, filename := range p {
+		if fileExists(filename) {
+			return filename
+		}
+	}
+	// otherwise the last file
+	return p[len(p)-1]
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func discardEmptyAndDuplicates(paths []string) []string {
+	seen := sets.NewString()
+	kept := 0
+	for _, p := range paths {
+		if p != "" && !seen.Has(p) {
+			paths[kept] = p
+			kept++
+			seen.Insert(p)
+		}
+	}
+	return paths[:kept]
+}
+
+// homeDir returns the home directory for the current user.
+// On Windows:
+// 1. the first of %HOME%, %HOMEDRIVE%%HOMEPATH%, %USERPROFILE% containing a `.kube\config` file is returned.
+// 2. if none of those locations contain a `.kube\config` file, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists and is writeable is returned.
+// 3. if none of those locations are writeable, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists is returned.
+// 4. if none of those locations exists, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that is set is returned.
+// NOTE this is from client-go. Rather than pull in client-go for this one
+// standalone method, we have a fork here.
+// https://github.com/kubernetes/client-go/blob/6d7018244d72350e2e8c4a19ccdbe4c8083a9143/util/homedir/homedir.go
+// We've modified this to require injecting os.Getenv and runtime.GOOS as a dependencies for testing purposes
+func homeDir(GOOS string, getEnv func(string) string) string {
+	if GOOS == "windows" {
+		home := getEnv("HOME")
+		homeDriveHomePath := ""
+		if homeDrive, homePath := getEnv("HOMEDRIVE"), getEnv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
+			homeDriveHomePath = homeDrive + homePath
+		}
+		userProfile := getEnv("USERPROFILE")
+
+		// Return first of %HOME%, %HOMEDRIVE%/%HOMEPATH%, %USERPROFILE% that contains a `.kube\config` file.
+		// %HOMEDRIVE%/%HOMEPATH% is preferred over %USERPROFILE% for backwards-compatibility.
+		for _, p := range []string{home, homeDriveHomePath, userProfile} {
+			if len(p) == 0 {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(p, ".kube", "config")); err != nil {
+				continue
+			}
+			return p
+		}
+
+		firstSetPath := ""
+		firstExistingPath := ""
+
+		// Prefer %USERPROFILE% over %HOMEDRIVE%/%HOMEPATH% for compatibility with other auth-writing tools
+		for _, p := range []string{home, userProfile, homeDriveHomePath} {
+			if len(p) == 0 {
+				continue
+			}
+			if len(firstSetPath) == 0 {
+				// remember the first path that is set
+				firstSetPath = p
+			}
+			info, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			if len(firstExistingPath) == 0 {
+				// remember the first path that exists
+				firstExistingPath = p
+			}
+			if info.IsDir() && info.Mode().Perm()&(1<<(uint(7))) != 0 {
+				// return first path that is writeable
+				return p
+			}
+		}
+
+		// If none are writeable, return first location that exists
+		if len(firstExistingPath) > 0 {
+			return firstExistingPath
+		}
+
+		// If none exist, return first location that is set
+		if len(firstSetPath) > 0 {
+			return firstSetPath
+		}
+
+		// We've got nothing
+		return ""
+	}
+	return getEnv("HOME")
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"io/ioutil"
+	"os"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// KINDFromRawKubeadm returns a kind kubeconfig derived from the raw kubeadm kubeconfig,
+// the kind clusterName, and the server.
+// server is ignored if unset.
+func KINDFromRawKubeadm(rawKubeadmKubeConfig, clusterName, server string) (*Config, error) {
+	cfg := &Config{}
+	if err := yaml.Unmarshal([]byte(rawKubeadmKubeConfig), cfg); err != nil {
+		return nil, err
+	}
+
+	// verify assumptions about kubeadm kubeconfigs
+	if err := checkKubeadmExpectations(cfg); err != nil {
+		return nil, err
+	}
+
+	// compute unique kubeconfig key for this cluster
+	key := KINDClusterKey(clusterName)
+
+	// use the unique key for all named references
+	cfg.Clusters[0].Name = key
+	cfg.Users[0].Name = key
+	cfg.Contexts[0].Name = key
+	cfg.Contexts[0].Context.User = key
+	cfg.Contexts[0].Context.Cluster = key
+	cfg.CurrentContext = key
+
+	// patch server field if server was set
+	if server != "" {
+		cfg.Clusters[0].Cluster.Server = server
+	}
+
+	return cfg, nil
+}
+
+// read loads a KUBECONFIG file from configPath
+func read(configPath string) (*Config, error) {
+	// try to open, return default if no such file
+	f, err := os.Open(configPath)
+	if os.IsNotExist(err) {
+		return &Config{}, nil
+	} else if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	// otherwise read in and deserialize
+	cfg := &Config{}
+	rawExisting, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if err := yaml.Unmarshal(rawExisting, cfg); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return cfg, nil
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"os"
+
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// RemoveKIND removes the kind cluster kindClusterName from the KUBECONFIG
+// files at configPaths
+func RemoveKIND(kindClusterName string, explicitPath string) error {
+	// remove kind from each if present
+	for _, configPath := range paths(explicitPath, os.Getenv) {
+		if err := func(configPath string) error {
+			// lock before modifying
+			if err := lockFile(configPath); err != nil {
+				return errors.Wrap(err, "failed to lock config file")
+			}
+			defer func(configPath string) {
+				_ = unlockFile(configPath)
+			}(configPath)
+
+			// read in existing
+			existing, err := read(configPath)
+			if err != nil {
+				return errors.Wrap(err, "failed to read kubeconfig to remove KIND entry")
+			}
+
+			// remove the kind cluster from the config
+			if remove(existing, kindClusterName) {
+				// write out the updated config if we modified anything
+				if err := write(existing, configPath); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}(configPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// remove drops kindClusterName entries from the cfg
+func remove(cfg *Config, kindClusterName string) bool {
+	mutated := false
+
+	// get kind cluster identifier
+	key := KINDClusterKey(kindClusterName)
+
+	// filter out kind cluster from clusters
+	kept := 0
+	for _, c := range cfg.Clusters {
+		if c.Name != key {
+			cfg.Clusters[kept] = c
+			kept++
+		} else {
+			mutated = true
+		}
+	}
+	cfg.Clusters = cfg.Clusters[:kept]
+
+	// filter out kind cluster from users
+	kept = 0
+	for _, u := range cfg.Users {
+		if u.Name != key {
+			cfg.Users[kept] = u
+			kept++
+		} else {
+			mutated = true
+		}
+	}
+	cfg.Users = cfg.Users[:kept]
+
+	// filter out kind cluster from contexts
+	kept = 0
+	for _, c := range cfg.Contexts {
+		if c.Name != key {
+			cfg.Contexts[kept] = c
+			kept++
+		} else {
+			mutated = true
+		}
+	}
+	cfg.Contexts = cfg.Contexts[:kept]
+
+	// unset current context if it points to this cluster
+	if cfg.CurrentContext == key {
+		cfg.CurrentContext = ""
+		mutated = true
+	}
+
+	return mutated
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/types.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/types.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+/*
+NOTE: all of these types are based on the upstream v1 types from client-go
+https://github.com/kubernetes/client-go/blob/0bdba2f9188006fc64057c2f6d82a0f9ee0ee422/tools/clientcmd/api/v1/types.go
+
+We've forked them to:
+- remove types and fields kind does not need to inspect / modify
+- generically support fields kind doesn't inspect / modify using yaml.v3
+- have clearer names (AuthInfo -> User)
+*/
+
+// Config represents a KUBECONFIG, with the fields kind is likely to use
+// Other fields are handled as unstructured data purely read for writing back
+// to disk via the OtherFields field
+type Config struct {
+	// Clusters is a map of referenceable names to cluster configs
+	Clusters []NamedCluster `yaml:"clusters,omitempty"`
+	// Users is a map of referenceable names to user configs
+	Users []NamedUser `yaml:"users,omitempty"`
+	// Contexts is a map of referenceable names to context configs
+	Contexts []NamedContext `yaml:"contexts,omitempty"`
+	// CurrentContext is the name of the context that you would like to use by default
+	CurrentContext string `yaml:"current-context,omitempty"`
+	// OtherFields contains fields kind does not inspect or modify, these are
+	// read purely for writing back
+	OtherFields map[string]interface{} `yaml:",inline,omitempty"`
+}
+
+// NamedCluster relates nicknames to cluster information
+type NamedCluster struct {
+	// Name is the nickname for this Cluster
+	Name string `yaml:"name"`
+	// Cluster holds the cluster information
+	Cluster Cluster `yaml:"cluster"`
+}
+
+// Cluster contains information about how to communicate with a kubernetes cluster
+type Cluster struct {
+	// Server is the address of the kubernetes cluster (https://hostname:port).
+	Server string `yaml:"server,omitempty"`
+	// OtherFields contains fields kind does not inspect or modify, these are
+	// read purely for writing back
+	OtherFields map[string]interface{} `yaml:",inline,omitempty"`
+}
+
+// NamedUser relates nicknames to user information
+type NamedUser struct {
+	// Name is the nickname for this User
+	Name string `yaml:"name"`
+	// User holds the user information
+	// We do not touch this and merely write it back
+	User map[string]interface{} `yaml:"user"`
+}
+
+// NamedContext relates nicknames to context information
+type NamedContext struct {
+	// Name is the nickname for this Context
+	Name string `yaml:"name"`
+	// Context holds the context information
+	Context Context `yaml:"context"`
+}
+
+// Context is a tuple of references to a cluster (how do I communicate with a kubernetes cluster), a user (how do I identify myself), and a namespace (what subset of resources do I want to work with)
+type Context struct {
+	// Cluster is the name of the cluster for this context
+	Cluster string `yaml:"cluster"`
+	// User is the name of the User for this context
+	User string `yaml:"user"`
+	// OtherFields contains fields kind does not inspect or modify, these are
+	// read purely for writing back
+	OtherFields map[string]interface{} `yaml:",inline,omitempty"`
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// write writes cfg to configPath
+// it will ensure the directories in the path if necessary
+func write(cfg *Config, configPath string) error {
+	encoded, err := Encode(cfg)
+	if err != nil {
+		return err
+	}
+	// NOTE: 0755 / 0600 are to match client-go
+	dir := filepath.Dir(configPath)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return errors.Wrap(err, "failed to create directory for KUBECONFIG")
+		}
+	}
+	if err := ioutil.WriteFile(configPath, encoded, 0600); err != nil {
+		return errors.Wrap(err, "failed to write KUBECONFIG")
+	}
+	return nil
+}

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/kubeconfig.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/kubeconfig.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfig provides utilities kind uses internally to manage
+// kind cluster kubeconfigs
+package kubeconfig
+
+import (
+	"bytes"
+
+	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+	"sigs.k8s.io/kind/pkg/errors"
+
+	// this package has slightly more generic kubeconfig helpers
+	// and minimal dependencies on the rest of kind
+	"sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig"
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers"
+)
+
+// Export exports the kubeconfig given the cluster context and a path to write it to
+// This will always be an external kubeconfig
+func Export(p providers.Provider, name, explicitPath string) error {
+	cfg, err := get(p, name, true)
+	if err != nil {
+		return err
+	}
+	return kubeconfig.WriteMerged(cfg, explicitPath)
+}
+
+// Remove removes clusterName from the kubeconfig paths detected based on
+// either explicitPath being set or $KUBECONFIG or $HOME/.kube/config, following
+// the rules set by kubectl
+// clusterName must identify a kind cluster.
+func Remove(clusterName, explicitPath string) error {
+	return kubeconfig.RemoveKIND(clusterName, explicitPath)
+}
+
+// Get returns the kubeconfig for the cluster
+// external controls if the internal IP address is used or the host endpoint
+func Get(p providers.Provider, name string, external bool) (string, error) {
+	cfg, err := get(p, name, external)
+	if err != nil {
+		return "", err
+	}
+	b, err := kubeconfig.Encode(cfg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), err
+}
+
+// ContextForCluster returns the context name for a kind cluster based on
+// it's name. This key is used for all list entries of kind clusters
+func ContextForCluster(kindClusterName string) string {
+	return kubeconfig.KINDClusterKey(kindClusterName)
+}
+
+func get(p providers.Provider, name string, external bool) (*kubeconfig.Config, error) {
+	// find a control plane node to get the kubeadm config from
+	n, err := p.ListNodes(name)
+	if err != nil {
+		return nil, err
+	}
+	var buff bytes.Buffer
+	nodes, err := nodeutils.ControlPlaneNodes(n)
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes) < 1 {
+		return nil, errors.New("could not locate any control plane nodes")
+	}
+	node := nodes[0]
+
+	// grab kubeconfig version from the node
+	if err := node.Command("cat", "/etc/kubernetes/admin.conf").SetStdout(&buff).Run(); err != nil {
+		return nil, errors.Wrap(err, "failed to get cluster internal kubeconfig")
+	}
+
+	// if we're doing external we need to override the server endpoint
+	server := ""
+	if external {
+		endpoint, err := p.GetAPIServerEndpoint(name)
+		if err != nil {
+			return nil, err
+		}
+		server = "https://" + endpoint
+	}
+
+	// actually encode
+	return kubeconfig.KINDFromRawKubeadm(buff.String(), name, server)
+}


### PR DESCRIPTION
.gitignore excludes kubeconfig from vendor and breaks CI builds. I will put a patch upstream to have it included in next rebase.