### PR TITLE
UPSTREAM: <carry>: remove "coverage.*" from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ bin
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-coverage.*
 
 # Ansible
 *.retry


### PR DESCRIPTION
This entity blocks adding coverage.go file in the vendor folder.