### PR TITLE
Disable VMExtensions

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -312,6 +312,10 @@ func ManagedClusterID(subscriptionID, resourceGroup, managedClusterName string) 
 // This extension allows running arbitrary scripts on the VM.
 // Its role is to detect and report Kubernetes bootstrap failure or success.
 func GetBootstrappingVMExtension(osType string, cloud string, vmName string) *ExtensionSpec {
+	//VMExtensions are disabled on openshift
+	if len("DISABLE") > 0 {
+		return nil
+	}
 	// currently, the bootstrap extension is only available in AzurePublicCloud.
 	if osType == LinuxOS && cloud == azureautorest.PublicCloud.Name {
 		// The command checks for the existence of the bootstrapSentinelFile on the machine, with retries and sleep between retries.

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -491,6 +491,10 @@ func TestMachineScope_RoleAssignmentSpecs(t *testing.T) {
 }
 
 func TestMachineScope_VMExtensionSpecs(t *testing.T) {
+	// VMExtensions are disabled on openshift
+	if len("DISABLE") > 0 {
+		return
+	}
 	tests := []struct {
 		name         string
 		machineScope MachineScope


### PR DESCRIPTION
This patch adds a check to `AzureMachineTemplate` webhook that rejects any template with VMExtension field set and stubs the `GetBootstrappingVMExtension` function to always return nil, disabling bootstrap VMextension.

For VMExtensions to work on OpenShift, we would be required to ship the Azure agent with our images. We are not currently interested in supporting VMExtensions. 