### PR TITLE
ART-12521: update go mod dependency for konflux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ bin
 .env
 envfile
 
+# For konflux
+!vendor/github.com/subosito/gotenv/.env
+
 # kubeconfigs
 kind.kubeconfig
 minikube.kubeconfig

--- a/vendor/github.com/subosito/gotenv/.env
+++ b/vendor/github.com/subosito/gotenv/.env
@@ -1,0 +1,1 @@
+HELLO=world


### PR DESCRIPTION
Image build was failing on Konflux due to missing go mod dependencies.

```
2025-04-04 17:29:55,704 INFO Vendoring the gomod dependencies
2025-04-04 17:30:10,676 ERROR vendor directory changed after vendoring:
A	vendor/github.com/subosito/gotenv/.env
2025-04-04 17:30:13,836 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
```

Konflux ignores .gitignore files since its a possible security gap. 