### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -10870,6 +10870,8 @@ spec:
         - --insecure-diagnostics=${CAPZ_INSECURE_DIAGNOSTICS:=false}
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKSResourceHealth=${EXP_AKS_RESOURCE_HEALTH:=false},EdgeZone=${EXP_EDGEZONE:=false},ASOAPI=false
         - --v=0
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         env:
         - name: AZURE_SUBSCRIPTION_ID
           valueFrom:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -15,3 +15,15 @@ images:
 patches:
 - path: ./patches/turn-off-aso-api.yaml
 - path: ./patches/credentials.yaml
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+- target:
+    kind: Deployment
+    name: capz-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Controller manager deployment now supports configurable TLS settings: operators can set a minimum TLS version and specify cipher suites via environment-driven configuration. This enables enforcing stronger TLS policies or customizing allowed ciphers without rebuilding or replacing the controller image, simplifying rollout of security policy changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->