### PR TITLE
NO-JIRA: manifests-gen: scope provider webhooks to capi namespace

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -10985,6 +10985,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachinepool
   failurePolicy: Fail
   name: default.azuremachinepool.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11007,6 +11010,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.azurecluster.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11029,6 +11035,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.azureclustertemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11051,6 +11060,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.azuremachine.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11073,6 +11085,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.azuremachinetemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11094,6 +11109,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane
   failurePolicy: Fail
   name: default.azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11115,6 +11133,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplanetemplate
   failurePolicy: Fail
   name: default.azuremanagedcontrolplanetemplates.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11137,6 +11158,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11158,6 +11182,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepooltemplate
   failurePolicy: Fail
   name: default.azuremanagedmachinepooltemplates.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11189,6 +11216,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachinepoolmachine
   failurePolicy: Fail
   name: azuremachinepoolmachine.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11210,6 +11240,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachinepool
   failurePolicy: Fail
   name: validation.azuremachinepool.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11231,6 +11264,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azureasomanagedcluster
   failurePolicy: Fail
   name: validation.azureasomanagedcluster.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11251,6 +11287,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azureasomanagedcontrolplane
   failurePolicy: Fail
   name: validation.azureasomanagedcontrolplane.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11271,6 +11310,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azureasomanagedmachinepool
   failurePolicy: Fail
   name: validation.azureasomanagedmachinepool.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11292,6 +11334,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.azurecluster.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11314,6 +11359,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.azureclusteridentity.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11336,6 +11384,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.azureclustertemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11358,6 +11409,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.azuremachine.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11380,6 +11434,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.azuremachinetemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11401,6 +11458,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcluster
   failurePolicy: Fail
   name: validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11422,6 +11482,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedclustertemplate
   failurePolicy: Fail
   name: validation.azuremanagedclustertemplates.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11442,6 +11505,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane
   failurePolicy: Fail
   name: validation.azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11463,6 +11529,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplanetemplate
   failurePolicy: Fail
   name: validation.azuremanagedcontrolplanetemplates.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11485,6 +11554,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -11507,6 +11579,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedmachinepooltemplate
   failurePolicy: Fail
   name: validation.azuremanagedmachinepooltemplates.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.25.3
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -95,8 +95,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80 h1:r0S/yoZAI0iWo1JvoIijaIgWGWf/izg4WiV7Wrtz16k=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c h1:brDtyXDZ8M/6KpJ9rsXQ3KKGawgN4TeiD4NpjFvu3V4=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c h1:mCbdsqRsXvIw22zy5c07zmFpaE/ng6ehx0Pq399UM3w=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
@@ -3,6 +3,31 @@ kind: Component
 
 namespace: openshift-cluster-api
 
+resources:
+  - webhook-namespace-selector.yaml
+
+# Scope all provider webhooks to the openshift-cluster-api namespace.
+# This prevents webhooks from intercepting requests in other namespaces,
+# which would fail on unsupported platforms where the webhook server is not running.
+replacements:
+  - source:
+      kind: ConfigMap
+      name: webhook-namespace-selector
+      fieldPath: data.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+
 patches:
 
 # Retain Secrets internally for reference tracking, but don't emit them
@@ -14,6 +39,7 @@ patches:
     metadata:
       name: __ignored__
       annotations:
+        # Marks this resource as local-only so kustomize excludes it from the final output.
         config.kubernetes.io/local-config: "true"
 
 # Set OpenShift pod annotations on all Deployments' pod templates.

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
@@ -1,0 +1,14 @@
+# This ConfigMap is a kustomize workaround: replacements need a concrete source resource
+# to read a value from, but there is no real resource that holds the target namespace.
+# This ConfigMap acts as that source, providing the namespace value to inject into webhook
+# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# It is marked as local-config so kustomize never emits it in the final output.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webhook-namespace-selector
+  annotations:
+    # Marks this resource as local-only so kustomize excludes it from the final output.
+    config.kubernetes.io/local-config: "true"
+data:
+  namespace: openshift-cluster-api

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/opencontainers/go-digest
 # github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80
 ## explicit; go 1.25.0
 github.com/openshift/api/config/v1
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 ## explicit; go 1.25.0
 github.com/openshift/cluster-capi-operator/manifests-gen
 github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata


### PR DESCRIPTION
Bumps `manifests-gen` to include webhook namespace scoping, which adds a `namespaceSelector` to all provider webhooks restricting them to the `openshift-cluster-api` namespace.

This prevents webhooks from intercepting requests in other namespaces, which would fail on unsupported platforms where the webhook server is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restricted cluster API admission webhooks to operate within their designated namespace for improved isolation
  * Updated manifests-gen dependency version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->