### PR TITLE
NO-JIRA: Don't specify rules in aggregated cluster role

### DIFF
--- a/config/rbac/aggregation_role.yaml
+++ b/config/rbac/aggregation_role.yaml
@@ -7,4 +7,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       cluster.x-k8s.io/aggregate-to-capz-manager: "true"
-rules: []

--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -10770,7 +10770,6 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
   name: capz-manager-role
-rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Backport of upstream PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6346

Fixes an issue where the CAPZ manifests will be continuously reconciled if they
are monitored by an operator which expects its own managed fields to be
unaltered.

By specifying an explicitly empty ruleset we:
* own the rules field
* assert that it is explicitly empty, given that it is atomic

The aggregation controller populates the field itself when it writes the rules
to it, which results in a conflict the next time we reconcile the manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes cluster role configuration to rely on aggregation rules, allowing role permissions to be composed via labeled role selection for simpler, more maintainable access control configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->